### PR TITLE
Simplify concept definitions:

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -124,8 +124,8 @@ concept bool Common =
     typename CommonType<T, U>;
     @\newtxt{typename CommonType<U, T>;}@
     @\newtxt{requires Same<CommonType<U, T>, CommonType<T, U> >;}@
-    {CommonType<T, U>@\oldtxt{\{}\newtxt{(}@forward<T>(t)@\oldtxt{\}}\newtxt{)}@};
-    {CommonType<T, U>@\oldtxt{\{}\newtxt{(}@forward<U>(u)@\oldtxt{\}}\newtxt{)}@};
+    @\oldtxt{\{}@CommonType<T, U>@\oldtxt{\{}\newtxt{(}@forward<T>(t)@\newtxt{)}\oldtxt{\}\}}@;
+    @\oldtxt{\{}@CommonType<T, U>@\oldtxt{\{}\newtxt{(}@forward<U>(u)@\newtxt{)}\oldtxt{\}\}}@;
   };
 \end{itemdecl}
 
@@ -157,7 +157,7 @@ user-defined type. Those specializations are considered by the \tcode{Common} co
 template <class B>
 concept bool Boolean =
   requires(B b1, B b2) {
-    { bool(b1) };
+    @\oldtxt{\{ }@bool(b1)@\oldtxt{ \}}@;
     { !b1 } -> Boolean;
     @\oldtxt{requires Same<decltype(b1 \&\& b2), bool>};@
     @\newtxt{\{b1 \&\& b2\} -> Same<bool>;}@
@@ -646,8 +646,8 @@ concept bool Semiregular =
     @\newtxt{\{new T\} -> Same<T*>;}@
     @\newtxt{\{new T[n]\} -> Same<T*>;}@
     // Deallocation
-    { delete new T };
-    { delete new T[n] };
+    @\oldtxt{\{ }@delete new T@\oldtxt{ \}}@;
+    @\oldtxt{\{ }@delete new T[n]@\oldtxt{ \}}@;
   };
 \end{itemdecl}
 
@@ -793,7 +793,7 @@ concept bool Function =
     { f.~F() } noexcept;
     @\oldtxt{requires Same<F*, decltype(new F)>;}@
     @\newtxt{\{ new F \} -> Same<F*>;}@
-    { delete new F };
+    @\oldtxt{\{ }@delete new F@\oldtxt{ \}}@;
     @\oldtxt{\{ f(forward<Args>(args)...) \};}@
     @\oldtxt{requires Same<ResultType<F, Args...>,}@
                   @\oldtxt{decltype(f(forward<Args>(args)...))>;}@

--- a/iterators.tex
+++ b/iterators.tex
@@ -341,7 +341,7 @@ referenced object.
   concept bool MoveWritable =
     Semiregular<Out> &&
     requires (Out o, T v) {
-      { *o = move(v) };
+      @\oldtxt{\{ }@*o = move(v)@\oldtxt{ \}}@;
     };
 \end{codeblock}
 
@@ -383,7 +383,7 @@ referenced object.
     @\oldtxt{Semiregular<Out> \&\&}@
     MoveWritable<Out, T> &&
     requires (Out o, T v) {
-      { *o = v };
+      @\oldtxt{\{ }@*o = v@\oldtxt{ \}}@;
     };
 \end{codeblock}
 
@@ -480,7 +480,7 @@ nor is the type required to be \tcode{EqualityComparable}.
       @\oldtxt{\{ ++i \};}@
       @\oldtxt{requires Same<I\&, decltype(++i)>;}@
       @\newtxt{\{ ++i \} -> Same<I\&>;}@
-      { i++ };
+      @\oldtxt{\{ }@i++@\oldtxt{ \}}@;
     };
 \end{codeblock}
 
@@ -929,7 +929,7 @@ notation via subscripting.
     @\newtxt{Iterator<I> \&\&}@
     @\newtxt{requires(I i) \{}@
         @\newtxt{\{ *i \} -> auto\&;}@
-        @\newtxt{\{ *i = *i \};}@
+        @\newtxt{*i = *i;}@
     @\newtxt{\};}@
 
   template <class I>
@@ -956,7 +956,7 @@ notation via subscripting.
       @\newtxt{\{ i - n \} -> Same<I>;}@
       @\oldtxt{\{ i[n] \} -> const ValueType<I>\&;}@
       @\newtxt{(\xname{MutableIterator}<I> ?}@
-        @\newtxt{requires(I i, int n) \{ \{ i[n] = *i \}; \{ *i = i[n] \}; \} :}@
+        @\newtxt{requires(I i, int n) \{ i[n] = *i; *i = i[n]; \} :}@
         @\newtxt{requires(I i, int n) \{ \{ i[n] \} -> const ValueType<I> \&; \});}@
     };
 \end{codeblock}


### PR DESCRIPTION
Convert compound-requirements that introduce only an expression constraint into equivalent simple-requirements. C++ has enough curly braces as it is, we don't need to add them in places where they have no effect ;)