### PR TITLE
Fix bibliography generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,21 @@
 
 FIGURES = $(patsubst %.dot,%.pdf,$(wildcard *.dot))
 
-TSPDF = pdflatex -jobname=DXXXX N4382.tex | grep -v "^Overfull"
+TSPDF = pdflatex -jobname=$(TARGET) N4382.tex | grep -v "^Overfull"
+
+TARGET = DXXXX
 
 default: rebuild
 
 clean:
-	rm -f *.aux N4382.pdf *.idx *.ilg *.ind *.log *.lot *.lof *.tmp *.out
+	rm -f *.aux $(TARGET).pdf *.idx *.ilg *.ind *.log *.lot *.lof *.tmp *.out
 
 refresh:
 	$(TSPDF)
 
 rebuild:
 	$(TSPDF)
-	bibtex N4382
+	bibtex $(TARGET)
 	$(TSPDF)
 	$(TSPDF)
 


### PR DESCRIPTION
The bibliography isn't being pulled into DXXXX correctly because the Makefile is still trying to `bibtex N4382` instead of `bibtex DXXXX`.