### PR TITLE
Wording for distance(Range). Fixes issue ericniebler/stl2#76.

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -1327,6 +1327,8 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges_v1 \{}@
     DifferenceType<I> advance(I& i, DifferenceType<I> n, S bound);
   template <Iterator I, Sentinel<I> S>
     DifferenceType<I> distance(I first, S last);
+  @\newtxt{template <Range R>}@
+    @\newtxt{DifferenceType<IteratorType<R>{}> distance(R\&\& range);}@
   template <WeakIterator I>
     I next(I x, DifferenceType<I> n = 1);
   template <Iterator I, Sentinel<I> S>
@@ -2390,9 +2392,7 @@ template <Iterator I, Sentinel<I> S>
 
 \begin{itemdescr}
 \pnum
-\effects
-
-If \removed{\tcode{InputIterator} meets the requirements of random access iterator}
+\effects If \removed{\tcode{InputIterator} meets the requirements of random access iterator}
 \newtxt{\tcode{SizedIteratorRange<I,S>()} is satisfied}, returns \tcode{(last - first)}; otherwise,
 returns the number of increments needed to get from
 \tcode{first}
@@ -2407,6 +2407,19 @@ If \removed{\tcode{InputIterator} meets the requirements of random access iterat
 \tcode{last}
 shall be reachable from
 \tcode{first}.
+\end{itemdescr}
+
+\begin{addedblock}
+\begin{itemdecl}
+@\newtxt{template <Range R>}@
+  @\newtxt{DifferenceType<IteratorType<R>{}> distance(R\&\& range);}@
+\end{itemdecl}
+\end{addedblock}
+
+\begin{itemdescr}
+\pnum
+\returns \newtxt{\tcode{size(r)} if \tcode{SizedRange<R>()} is satisfied;
+otherwise \tcode{distance(begin(r), end(r))}.}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{next}}%


### PR DESCRIPTION
Wording itself is simple enough, organization is awkward. I inserted the para immediately after the wording for `distance(Iterator, Sentinel)` where I think it belongs. It's peculiar, however, that it appears before the range concepts are defined. In a perfect world, I would relocate the range concepts section before the `<iterator>` synoposis to correct the issue.