### PR TITLE
"undefined" -> "unspecified"

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -138,7 +138,7 @@ struct T {
 \end{codeblock}
 
 Since \tcode{T} fails to satisfy the implicit requirements of \tcode{C}, \tcode{C<T>()} is not
-satisfied in principle. Whether it is satisfied in practice is undefined.
+satisfied in principle. Whether it is satisfied in practice is unspecified.
 \exitexample
 }
 


### PR DESCRIPTION
You do not want undefined behavior when the implementation decides not to check the additional constraints.