### PR TITLE
Removed casts to void

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -326,7 +326,7 @@ Then \oldtxt{types \tcode{T} and \tcode{U} model} \tcode{Assignable\newtxt{<T, U
 template <class T>
 concept bool Swappable() {
   return requires(T t, T u) {
-    @\newtxt{(void)}@swap(std::forward<T>(t), std::forward<T>(u));
+    swap(std::forward<T>(t), std::forward<T>(u));
   };
 }
 
@@ -336,8 +336,8 @@ concept bool Swappable() {
     Swappable<U>() &&
     Common<T, U>@\newtxt{()}@ &&
     requires(T t, U u) {
-      @\newtxt{(void)}@swap(std::forward<T>(t), std::forward<U>(u));
-      @\newtxt{(void)}@swap(std::forward<U>(u), std::forward<T>(t));
+      swap(std::forward<T>(t), std::forward<U>(u));
+      swap(std::forward<U>(u), std::forward<T>(t));
     };
 }
 \end{itemdecl}


### PR DESCRIPTION
The casts are needed in Ranges v3, because the constrains are separated with commas. In C++ concepts, the constraints are separated by semicolons, so the cast to void adds nothing.
Also, the cast to void does not indicate that "we ignore the return value". It says "the result of swap should be castable to void", which is of no value.