### PR TITLE
IndirectlySwappable relates the *reference* types of two Readables

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -461,7 +461,7 @@ dereferenceable object of type \tcode{Out}. Then \oldtxt{types \tcode{I} and \tc
 
 \pnum
 The \tcode{IndirectlySwappable} concept describes a swappable relationship between the
-value types of two \tcode{Readable} types.
+\oldtxt{value}\newtxt{reference} types of two \tcode{Readable} types.
 
 \indexlibrary{\idxcode{IndirectlySwappable}}%
 \begin{codeblock}


### PR DESCRIPTION
Editorial.