### PR TITLE
Use "iff" instead of "only if" for dereferenceability of Bidi iterators

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -900,7 +900,7 @@ and adds the ability to move an iterator backward as well as forward.
 
 \begin{addedblock}
 \pnum
-A bidirectional iterator \tcode{r} is decrementable only if there exists some \tcode{s} such that
+A bidirectional iterator \tcode{r} is decrementable \newtxt{if and} only if there exists some \tcode{s} such that
 \tcode{++s == r}. The expressions \tcode{\dcr{}r} and \tcode{r\dcr{}} are only valid if \tcode{r} is
 decrementable.
 


### PR DESCRIPTION
Editorial.