### PR TITLE
Cleanup a few more bits of markup

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -738,7 +738,7 @@ references to [moveconstructible] with references to
 template <class T>
 concept bool MoveConstructible() {
   return Constructible<T, remove_cv_t<T>&&>() &&
-    Convertible@\newtxt{To}@<remove_cv_t<T>&&, T>();
+    ConvertibleTo<remove_cv_t<T>&&, T>();
 }
 \end{itemdecl}
 
@@ -777,9 +777,9 @@ template <class T>
 concept bool CopyConstructible() {
   return MoveConstructible<T>() &&
     Constructible<T, const remove_cv_t<T>&>() &&
-    Convertible@\newtxt{To}@<remove_cv_t<T>&, T>() &&
-    Convertible@\newtxt{To}@<const remove_cv_t<T>&, T>() &&
-    Convertible@\newtxt{To}@<const remove_cv_t<T>&&, T>();
+    ConvertibleTo<remove_cv_t<T>&, T>() &&
+    ConvertibleTo<const remove_cv_t<T>&, T>() &&
+    ConvertibleTo<const remove_cv_t<T>&&, T>();
 }
 \end{itemdecl}
 

--- a/decomposition.tex
+++ b/decomposition.tex
@@ -365,9 +365,9 @@ template <class F, class ...Args>
 concept bool Function() {
   return CopyConstructible<T>() &&
     requires (F f, Args&&...args) {
-      typename @\oldtxt{ResultType<F, Args...>}\newtxt{result_of_t<F\&(Args...)>}@;
+      typename result_of_t<F&(Args...)>;
       { f(std::forward<Args>(args)...) } ->
-        Same<@\oldtxt{ResultType<F, Args...>}\newtxt{result_of_t<F\&(Args...)>}@>;
+        Same<result_of_t<F&(Args...)>>;
     };
 }
 \end{codeblock}

--- a/deprecated.tex
+++ b/deprecated.tex
@@ -24,14 +24,14 @@ The following algorithms are deemed unsafe and are deprecated in this document.
 
 \begin{codeblock}
 // \ref{mismatch}, mismatch
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
     IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2,
+template<InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
     IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
@@ -40,14 +40,14 @@ template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2,
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 // \ref{alg.equal}, equal
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
   bool equal(I1 first1, S1 last1,
              I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2, class Pred = equal_to<>,
+template<InputRange Rng1, InputIterator I2, class Pred = equal_to<>,
     class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyComparable<iterator_t<Rng1>, I2, Pred, Proj1, Proj2>()
   bool equal(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -79,14 +79,14 @@ template<ForwardRange Rng, ForwardIterator I>
     swap_ranges(Rng&& rng1, I first2);
 
 // \ref{alg.transform}, transform
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2, WeaklyIncrementable O,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, WeaklyIncrementable O,
     class F, class Proj1 = identity, class Proj2 = identity>
   requires Writable<O, indirect_result_of_t<F&(projected<I1, Proj1>, projected<I2, Proj2>)>>()
   tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
     transform(I1 first1, S1 last1, I2 first2, O result,
               F binary_op, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng, @\oldtxt{Weak}@InputIterator I, WeaklyIncrementable O, class F,
+template<InputRange Rng, InputIterator I, WeaklyIncrementable O, class F,
     class Proj1 = identity, class Proj2 = identity>
   requires Writable<O, indirect_result_of_t<F&(
     projected<iterator_t<Rng>, Proj1>, projected<I, Proj2>>)>()


### PR DESCRIPTION
* concepts.tex: Some `Convertible@\newtxt{To}@` occurrences
* decomposition.tex, deprecated.tex: cleanup what little markup they have.