### PR TITLE
Use "Effects: Equivalent to" to specify distance in [ranges.primitives]

### DIFF
--- a/algorithms.tex
+++ b/algorithms.tex
@@ -1293,7 +1293,7 @@ iterator and sentinel arguments.
 \pnum
 Some algorithms declare both an overload that takes a \tcode{Range}
 and an \tcode{Iterator}, and an overload that takes two \tcode{Range}
-arguments. Since an array type~(\cxxref{basic.compound}) both satisifies
+parameters. Since an array type~(\cxxref{basic.compound}) both satisfies
 \tcode{Range} and decays to a pointer~(\cxxref{conv.array}) which satisfies
 \tcode{Iterator}, such overloads are ambiguous when an array is passed as
 the second argument. Implementations shall provide a mechanism to resolve

--- a/concepts.tex
+++ b/concepts.tex
@@ -738,7 +738,7 @@ references to [moveconstructible] with references to
 template <class T>
 concept bool MoveConstructible() {
   return Constructible<T, remove_cv_t<T>&&>() &&
-    Convertible@\newtxt{To}@<remove_cv_t<T>&&, T>();
+    ConvertibleTo<remove_cv_t<T>&&, T>();
 }
 \end{itemdecl}
 
@@ -777,9 +777,9 @@ template <class T>
 concept bool CopyConstructible() {
   return MoveConstructible<T>() &&
     Constructible<T, const remove_cv_t<T>&>() &&
-    Convertible@\newtxt{To}@<remove_cv_t<T>&, T>() &&
-    Convertible@\newtxt{To}@<const remove_cv_t<T>&, T>() &&
-    Convertible@\newtxt{To}@<const remove_cv_t<T>&&, T>();
+    ConvertibleTo<remove_cv_t<T>&, T>() &&
+    ConvertibleTo<const remove_cv_t<T>&, T>() &&
+    ConvertibleTo<const remove_cv_t<T>&&, T>();
 }
 \end{itemdecl}
 

--- a/decomposition.tex
+++ b/decomposition.tex
@@ -365,9 +365,9 @@ template <class F, class ...Args>
 concept bool Function() {
   return CopyConstructible<T>() &&
     requires (F f, Args&&...args) {
-      typename @\oldtxt{ResultType<F, Args...>}\newtxt{result_of_t<F\&(Args...)>}@;
+      typename result_of_t<F&(Args...)>;
       { f(std::forward<Args>(args)...) } ->
-        Same<@\oldtxt{ResultType<F, Args...>}\newtxt{result_of_t<F\&(Args...)>}@>;
+        Same<result_of_t<F&(Args...)>>;
     };
 }
 \end{codeblock}

--- a/deprecated.tex
+++ b/deprecated.tex
@@ -24,14 +24,14 @@ The following algorithms are deemed unsafe and are deprecated in this document.
 
 \begin{codeblock}
 // \ref{mismatch}, mismatch
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
     IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2,
+template<InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
     IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
@@ -40,14 +40,14 @@ template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2,
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 // \ref{alg.equal}, equal
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
   bool equal(I1 first1, S1 last1,
              I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng1, @\oldtxt{Weak}@InputIterator I2, class Pred = equal_to<>,
+template<InputRange Rng1, InputIterator I2, class Pred = equal_to<>,
     class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyComparable<iterator_t<Rng1>, I2, Pred, Proj1, Proj2>()
   bool equal(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -79,14 +79,14 @@ template<ForwardRange Rng, ForwardIterator I>
     swap_ranges(Rng&& rng1, I first2);
 
 // \ref{alg.transform}, transform
-template<InputIterator I1, Sentinel<I1> S1, @\oldtxt{Weak}@InputIterator I2, WeaklyIncrementable O,
+template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, WeaklyIncrementable O,
     class F, class Proj1 = identity, class Proj2 = identity>
   requires Writable<O, indirect_result_of_t<F&(projected<I1, Proj1>, projected<I2, Proj2>)>>()
   tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
     transform(I1 first1, S1 last1, I2 first2, O result,
               F binary_op, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
-template<InputRange Rng, @\oldtxt{Weak}@InputIterator I, WeaklyIncrementable O, class F,
+template<InputRange Rng, InputIterator I, WeaklyIncrementable O, class F,
     class Proj1 = identity, class Proj2 = identity>
   requires Writable<O, indirect_result_of_t<F&(
     projected<iterator_t<Rng>, Proj1>, projected<I, Proj2>>)>()

--- a/iterators.tex
+++ b/iterators.tex
@@ -6999,7 +6999,7 @@ difference_type_t<iterator_t<R>> distance(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{ranges::distance(ranges::begin(r), ranges::end(r))}
+\pnum \effects Equivalent to: \tcode{ranges::distance(ranges::begin(r), ranges::end(r))}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{distance(R\&\& r)}}%
@@ -7009,7 +7009,7 @@ difference_type_t<iterator_t<R>> distance(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{ranges::size(r)}
+\pnum \effects Equivalent to: \tcode{ranges::size(r)}
 \end{itemdescr}
 
 \rSec2[range.primitives.size]{\tcode{size}}

--- a/iterators.tex
+++ b/iterators.tex
@@ -1,5 +1,4 @@
 %!TEX root = std.tex
-
 \setcounter{chapter}{23}
 \rSec0[iterators]{Iterators library}
 
@@ -23,7 +22,7 @@ as summarized in Table~\ref{tab:iterators.lib.summary}.
 
 \begin{libsumtab}{Iterators library summary}{tab:iterators.lib.summary}
 \ref{iterator.requirements} & Requirements        &                           \\ \rowsep
-\ref{iterator.primitives} & Iterator primitives   &   \tcode{<\added{experimental/ranges\oldtxt{_v1}/}iterator>}      \\
+\ref{iterator.primitives} & Iterator primitives   &   \tcode{<\added{experimental/ranges/}iterator>}      \\
 \ref{iterators.predef} & Predefined iterators     &                           \\
 \ref{iterators.stream} & Stream iterators         &                           \\
 \added{\ref{ranges}} & \added{Ranges}             &                           \\
@@ -67,24 +66,22 @@ with the same semantics as
 \tcode{(*i).m}.}
 For every iterator type
 \tcode{X}
-\oldoldtxt{for which
+\removed{for which
 equality is defined}, there is a corresponding signed integer type called the
 \term{difference type}
 of the iterator.
 
 \pnum
-Since iterators are an abstraction of pointers, their semantics \oldoldtxt{is}\newtxt{are}
+Since iterators are an abstraction of pointers, their semantics \changed{is}{are}
 a generalization of most of the semantics of pointers in \Cpp.
 This ensures that every
 function template
 that takes iterators
 works as well with regular pointers.
 This International Standard defines
-five\oldtxt{seven} categories of iterators, according to the operations
+five categories of iterators, according to the operations
 defined on them:
-\oldtxt{\techterm{weak input iterators}, }
 \techterm{input iterators},
-\oldtxt{\techterm{weak output iterators}, }
 \techterm{output iterators},
 \techterm{forward iterators},
 \techterm{bidirectional iterators}
@@ -93,38 +90,34 @@ and
 as shown in Table~\ref{tab:iterators.relations}.
 
 \begin{floattable}{Relations among iterator categories}{tab:iterators.relations}
-{lllll}
+{llll}
 \topline
 \textbf{Random Access}          &   $\rightarrow$ \textbf{Bidirectional}    &
-$\rightarrow$ \textbf{Forward}  &   $\rightarrow$ \textbf{Input}            & \oldtxt{   $\rightarrow$ \textbf{WeakInput}}           \\
-                        &   &   &   $\rightarrow$ \textbf{Output}           & \oldtxt{   $\rightarrow$ \textbf{WeakOutput}}          \\
+$\rightarrow$ \textbf{Forward}  &   $\rightarrow$ \textbf{Input}            \\
+                        &   &   &   $\rightarrow$ \textbf{Output}           \\
 \end{floattable}
 
 \begin{addedblock}
 \pnum
-The \oldtxt{seven}\newtxt{five} categories of iterators correspond to the iterator concepts
-\oldtxt{\tcode{WeakInputIterator},}
+The five categories of iterators correspond to the iterator concepts
 \tcode{InputIterator},
-\oldtxt{\tcode{WeakOutputIterator},}
 \tcode{OutputIterator},
-\tcode{ForwardIterator},
-\tcode{BidirectionalIterator}, and
+\tcode{Forward\-Iterator},
+\tcode{Bidirectional\-Iterator}, and
 \tcode{RandomAccess\-Iterator}, respectively. The generic term \techterm{iterator} refers to
-any type that satisfies \tcode{\oldtxt{Weak}Iterator}.
+any type that satisfies \tcode{Iterator}.
 \end{addedblock}
 
 \pnum
-Forward\oldtxt{Input} iterators satisfy all the requirements of \oldtxt{weak }input
-iterators and can be used whenever an\oldtxt{a weak} input iterator is specified;
-\oldtxt{Forward iterators also satisfy all the requirements of
-input iterators and can be used whenever an input iterator is specified;}
+Forward iterators satisfy all the requirements of input
+iterators and can be used whenever an input iterator is specified;
 Bidirectional iterators also satisfy all the requirements of
 forward iterators and can be used whenever a forward iterator is specified;
 Random access iterators also satisfy all the requirements of bidirectional
 iterators and can be used whenever a bidirectional iterator is specified.
 
 \pnum
-Iterators that further satisfy the requirements of \oldtxt{weak }output iterators are
+Iterators that further satisfy the requirements of output iterators are
 called \defn{mutable iterator}{s}. Nonmutable iterators are referred to
 as \defn{constant iterator}{s}.
 
@@ -170,20 +163,18 @@ values are always non-singular.
 \pnum
 A
 \term{sentinel}
-is an abstraction of a past-the-end iterator. \oldtxt{Sentinels
-are \tcode{Regular} types that can be used to denote the end of
-a range.} An iterator and a sentinel denoting a range
-\newtxt{are comparable}\oldtxt{shall be \tcode{EqualityComparable}}.
-A sentinel denotes an element when\newtxt{ it compares equal to}
-an iterator \tcode{i}\oldtxt{ compares equal to the sentinel}, and
-\tcode{i} points to that element. \newtxt{The types of a sentinel
+is an abstraction of a past-the-end iterator. An iterator and a sentinel denoting a range
+are comparable.
+A sentinel denotes an element when it compares equal to
+an iterator \tcode{i}, and
+\tcode{i} points to that element. The types of a sentinel
 and an iterator that denote a range must satisfy
-\tcode{Sentinel}~(\ref{iterators.sentinel}).}
+\tcode{Sentinel}~(\ref{iterators.sentinel}).
 \end{addedblock}
 
 \pnum
-\oldoldtxt{An iterator }\oldtxt{or }\newnewtxt{A }\added{sentinel}
-\tcode{\oldoldtxt{j}\newnewtxt{s}}
+\changed{An iterator }{A }\added{sentinel}
+\tcode{\changed{j}{s}}
 is called
 \term{reachable}
 from an iterator
@@ -192,29 +183,29 @@ if and only if there is a finite sequence of applications of
 the expression
 \tcode{++i}
 that makes
-\tcode{i == \oldoldtxt{j}\newnewtxt{s}}.
+\tcode{i == \changed{j}{s}}.
 If
-\tcode{\oldoldtxt{j}\newnewtxt{s}}
+\tcode{\changed{j}{s}}
 is reachable from
 \tcode{i},
-they \oldoldtxt{refer to elements of the same sequence}\newnewtxt{denote a range}.
+they \changed{refer to elements of the same sequence}{denote a range}.
 
 \pnum
 Most of the library's algorithmic templates that operate on data structures have interfaces that use ranges.
 A
 \term{range}
-is \oldoldtxt{a pair of iterators }\oldtxt{or }\added{an iterator and a sentinel} that designate the beginning and end of the computation.
-A range \oldoldtxt{\range{i}{i}}\newnewtxt{\range{i}{s}}
-is an empty range\newnewtxt{ if \tcode{i == s}};
-\oldoldtxt{in general, a range \range{i}{j}}\newnewtxt{otherwise, \range{i}{s}}
+is \changed{a pair of iterators }{an iterator and a sentinel} that designate the beginning and end of the computation.
+A range \removed{\range{i}{i}}\added{\range{i}{s}}
+is an empty range\added{ if \tcode{i == s}};
+\removed{in general, a range \range{i}{j}}\added{otherwise, \range{i}{s}}
 refers to the elements in the data structure starting with the element
 pointed to by
 \tcode{i}
-and up to but not including the element pointed to\oldtxt{denoted} by
-\newnewtxt{the first iterator} \tcode{j} \newnewtxt{such that \tcode{j == s}}.
-Range \oldoldtxt{\range{i}{j}}\newnewtxt{\range{i}{s}}
+and up to but not including the element pointed to by
+\added{the first iterator} \tcode{j} \added{such that \tcode{j == s}}.
+Range \removed{\range{i}{j}}\added{\range{i}{s}}
 is valid if and only if
-\oldoldtxt{\tcode{j}}\newnewtxt{\tcode{s}}
+\removed{\tcode{j}}\added{\tcode{s}}
 is reachable from
 \tcode{i}.
 The result of the application of functions in the library to invalid ranges is
@@ -237,7 +228,7 @@ The effect of dereferencing an iterator that has been invalidated
 is undefined.
 }
 
-\oldoldtxt{
+\removed{
 \pnum
 In the following sections,
 \tcode{a}
@@ -281,15 +272,15 @@ applying \tcode{operator*} including pointers, smart pointers, and iterators.
   concept bool Readable() {
     return Semiregular<I>() &&
       requires (const I i) {
-        typename @\oldtxt{ValueType}\newtxt{value_type_t}@<I>;
-        { *i } -> const @\oldtxt{ValueType}\newtxt{value_type_t}@<I>&; // pre: i is dereferenceable
+        typename value_type_t<I>;
+        { *i } -> const value_type_t<I>&; // pre: i is dereferenceable
       };
   }
 \end{codeblock}
 
 \pnum
 A \tcode{Readable} type has an associated value type that can be accessed with the
-\tcode{\oldtxt{ValueType}}\tcode{\newtxt{value_type_t}} alias template.
+\tcode{value_type_t} alias template.
 
 \indexlibrary{\idxcode{value_type_t}}%
 \begin{codeblock}
@@ -302,10 +293,6 @@ A \tcode{Readable} type has an associated value type that can be accessed with t
   struct value_type<I> : value_type<decay_t<I>> { };
   template <class I>
   struct value_type<I const> : value_type<decay_t<I>> { };
-  @\oldtxt{template <class I>}@
-  @\oldtxt{struct value_type<I volatile> : value_type<decay_t<I>{}> \{ \};}@
-  @\oldtxt{template <class I>}@
-  @\oldtxt{struct value_type<I const volatile> : value_type<decay_t<I>{}> \{ \};}@
   template <class T>
     requires requires { typename T::value_type; }
   struct value_type<T>
@@ -316,7 +303,7 @@ A \tcode{Readable} type has an associated value type that can be accessed with t
     : enable_if<is_object<typename T::element_type>::value, typename T::element_type> { };
 
   template <class T>
-    using @\oldtxt{ValueType}\newtxt{value_type_t}@ = typename value_type<T>::type;
+    using value_type_t = typename value_type<T>::type;
 \end{codeblock}
 
 \pnum
@@ -327,16 +314,16 @@ value type. Otherwise, there shall be no nested type \tcode{type}.
 The \tcode{value_type} class template may be specialized on user-defined types.
 
 \pnum
-When instantiated with a type \tcode{I} \oldtxt{that has a nested type \tcode{value_type}}
-\newtxt{such that \tcode{I::value_type} is valid and denotes a type},
+When instantiated with a type \tcode{I}
+such that \tcode{I::value_type} is valid and denotes a type,
 \tcode{value_type<I>::type} names that type, unless it is not an object type~(\cxxref{basic.types}) in which case
 \tcode{value_type<I>} shall have no nested type \tcode{type}. \enternote Some legacy output
 iterators define a nested type named \tcode{value_type} that is an alias for \tcode{void}. These
 types are not \tcode{Readable} and have no associated value types.\exitnote
 
 \pnum
-When instantiated with a type \tcode{I} \oldtxt{that has a nested type \tcode{element_type}}
-\newtxt{such that \tcode{I::element_type} is valid and denotes a type},
+When instantiated with a type \tcode{I}
+such that \tcode{I::element_type} is valid and denotes a type,
 \tcode{value_type<I>::type} names that type, unless it is not an object type~(\cxxref{basic.types}) in which case
 \tcode{value_type<I>} shall have no nested type \tcode{type}. \enternote Smart pointers like
 \tcode{shared_ptr<int>} are \tcode{Readable} and have an associated value type. But a smart pointer
@@ -345,38 +332,38 @@ like \tcode{shared_ptr<void>} is not \tcode{Readable} and has no associated valu
 \rSec2[iterators.writable]{Concept Writable}
 
 \pnum
-The \tcode{\oldtxt{Move}Writable} concept describes the requirements for \oldtxt{moving}\newtxt{writing} a value into an iterator's
+The \tcode{Writable} concept describes the requirements for writing a value into an iterator's
 referenced object.
 
 \indexlibrary{\idxcode{Writable}}%
 \begin{codeblock}
   template <class Out, class T>
-  concept bool @\oldtxt{Move}@Writable() {
+  concept bool Writable() {
     return Semiregular<Out>() &&
-      requires(Out o, T@\newtxt{\&\&}@ v) {
-        *o = std::@\oldtxt{move}\newtxt{forward<T>}@(v); // not required to be equality preserving
+      requires(Out o, T&& v) {
+        *o = std::forward<T>(v); // not required to be equality preserving
       };
   }
 \end{codeblock}
 
 \pnum
-Let \tcode{t} be an \oldtxt{rvalue or a lvalue of type (possibly \tcode{const})}\newtxt{an expression such that \tcode{decltype(t)} is} \tcode{T}, and let \tcode{o}
-be a dereferenceable object of type \tcode{Out}. Then \tcode{\oldtxt{Move}Writable<Out, T>()} is satisfied if and only if
+Let \tcode{t} be an an expression such that \tcode{decltype(t)} is \tcode{T}, and let \tcode{o}
+be a dereferenceable object of type \tcode{Out}. Then \tcode{Writable<Out, T>()} is satisfied if and only if
 
 \begin{itemize}
-\item If \oldtxt{\tcode{Out} is }\tcode{Readable<Out>()\newtxt{ \&\& Same<value_type_t<Out>, decay_t<T>{>}()}}\newtxt{ is satisfied},
-then\newtxt{ \tcode{*o}} after the assignment\oldtxt{ \tcode{*o = std::move(t)}, \tcode{*o}} is equal
+\item If \tcode{Readable<Out>() \&\& Same<value_type_t<Out>, decay_t<T>{>}()} is satisfied,
+then \tcode{*o} after the assignment is equal
 to the value of \tcode{t} before the assignment.
 \end{itemize}
 
 \pnum
-After\newtxt{ evaluating} the \newtxt{assignment }expression\oldtxt{ \tcode{*o = std::move(v)}}, \oldtxt{object }\tcode{o} is not required to be dereferenceable.
+After evaluating the assignment expression, \tcode{o} is not required to be dereferenceable.
 
 \pnum
-\oldtxt{\tcode{v}'s state}\newtxt{If \tcode{v} is an xvalue~(\cxxref{basic.lval}), the resulting
-state of the object it denotes} is unspecified. \enternote \oldtxt{\tcode{v}}\newtxt{The object} must still meet the
-requirements of \oldtxt{the}\newtxt{any} library component that is using it. The operations listed
-in those requirements must work as specified whether \oldtxt{\tcode{v}}\newtxt{the object} has been moved
+If \tcode{v} is an xvalue~(\cxxref{basic.lval}), the resulting
+state of the object it denotes is unspecified. \enternote The object must still meet the
+requirements of any library component that is using it. The operations listed
+in those requirements must work as specified whether the object has been moved
 from or not.\exitnote
 
 \ednote{``If \tcode{t} is an xvalue'' suffices for now, but incorporating P0022's proxy
@@ -387,34 +374,6 @@ from or not.\exitnote
 The only valid use of an \tcode{operator*} is on the left side of the assignment statement.
 \textit{Assignment through the same value of the writable type happens only once.}
 \exitnote
-
-{\color{oldclr}
-\rSec2[iterators.oldwritable]{(Was) Concept Writable}
-
-\pnum
-The \tcode{Writable} concept describes the requirements for copying a value into an iterator's
-referenced object.
-
-\begin{codeblock}
-  template <class Out, class T>
-  concept bool Writable() {
-    return MoveWritable<Out, T>() &&
-      requires (Out o, const T v) {
-        *o = v; // not required to be equality preserving
-      };
-  }
-\end{codeblock}
-
-\pnum
-Let \tcode{v} be an lvalue of type (possibly \tcode{const}) \tcode{T} or an rvalue
-of type \tcode{const T}, and let \tcode{o} be a dereferenceable object of type
-\tcode{Out}. Then \tcode{Writable<Out, T>()} is satisfied if and only if
-
-\begin{itemize}
-\item If \tcode{Out} is \tcode{Readable}, after the assignment \tcode{*o = v},
-\tcode{*o} is equal to the value of \tcode{v}.
-\end{itemize}
-} %% color{oldclr}
 
 \rSec2[iterators.weaklyincrementable]{Concept WeaklyIncrementable}
 
@@ -429,8 +388,8 @@ nor is the type required to be \tcode{EqualityComparable}.
   concept bool WeaklyIncrementable() {
     return Semiregular<I>() &&
       requires (I i) {
-        typename @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-        requires SignedIntegral<@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>>();
+        typename difference_type_t<I>;
+        requires SignedIntegral<difference_type_t<I>>();
         { ++i } -> Same<I&>; // not required to be equality preserving
         i++; // not required to be equality preserving
       };
@@ -506,12 +465,12 @@ algorithms with types that satisfy \tcode{Incrementable}.\exitnote
 \rSec2[iterators.iterator]{Concept Iterator}
 
 \pnum
-The \oldtxt{\tcode{Weak}}\tcode{Iterator} \changed{requirements}{concept} form\added{s}
+The \tcode{Iterator} \changed{requirements}{concept} form\added{s}
 the basis of the iterator concept taxonomy; every iterator satisfies the
-\oldtxt{\tcode{Weak}}\tcode{Iterator} requirements. This
+\tcode{Iterator} requirements. This
 \changed{set of requirements}{concept} specifies operations for dereferencing and incrementing
 an iterator. Most algorithms will require additional operations
-\added{to compare iterators\newtxt{ with sentinels}~(\ref{iterators.sentinel}),} to
+\added{to compare iterators with sentinels~(\ref{iterators.sentinel}),} to
 read~(\ref{iterators.input}) or write~(\ref{iterators.output}) values, or
 to provide a richer set of iterator movements~(\ref{iterators.forward},
 \ref{iterators.bidirectional}, \ref{iterators.random.access}).)
@@ -522,7 +481,7 @@ to provide a richer set of iterator movements~(\ref{iterators.forward},
 \indexlibrary{\idxcode{Iterator}}%
 \begin{codeblock}
   template <class I>
-  concept bool @\oldtxt{Weak}@Iterator() {
+  concept bool Iterator() {
     return WeaklyIncrementable<I>() &&
       requires(I i) {
         { *i } -> auto&&; // pre: i is dereferenceable
@@ -536,23 +495,21 @@ to provide a richer set of iterator movements~(\ref{iterators.forward},
 
 \rSec2[iterators.sentinel]{Concept Sentinel}
 \pnum
-The \tcode{Sentinel} concept \oldtxt{defines requirements for a type that
-is an abstraction of the past-the-end iterator. Its values can be
-compared to an iterator for equality.}\newtxt{specifies the relationship
+The \tcode{Sentinel} concept
+specifies the relationship
 between an \tcode{Iterator} type and a \tcode{Semiregular} type whose values
-denote a range.}
+denote a range.
 
 \indexlibrary{\idxcode{Sentinel}}%
 \begin{itemdecl}
-  template <class @\oldtxt{T}\newtxt{S}@, class I>
+  template <class S, class I>
   concept bool Sentinel() {
-    return @\newtxt{Semi}@regular<@\oldtxt{T}\newtxt{S}@>() &&
+    return Semiregular<S>() &&
       Iterator<I>() &&
-      @\newtxt{Weakly}@EqualityComparable<@\oldtxt{T}\newtxt{S}@, I>();
+      WeaklyEqualityComparable<S, I>();
   }
 \end{itemdecl}
 
-{\color{newclr}
 \begin{itemdescr}
 \pnum
 Let \tcode{s} and \tcode{i} be values of type \tcode{S} and
@@ -574,47 +531,16 @@ Given an iterator \tcode{i} and sentinel \tcode{s} such that \range{i}{s}
 denotes a range and \tcode{i != s}, \range{i}{s} is not required to continue to
 denote a range after incrementing any iterator equal to \tcode{i}. Consequently,
 \tcode{i == s} is no longer required to be well-defined.
-} %% color{newclr}
 
 \rSec2[iterators.sizedsentinel]{Concept SizedSentinel}
 \pnum
-The \tcode{Sized\oldtxt{IteratorRange}\newtxt{Sentinel}} concept specifies\oldtxt{ the}
-requirements on a\newtxt{n} \tcode{Iterator}\oldtxt{~(\ref{iterators.iterator})} and a \tcode{Sentinel}
-that allow\oldtxt{s} the use of the \tcode{-} operator to compute the distance
+The \tcode{SizedSentinel} concept specifies
+requirements on an \tcode{Iterator} and a \tcode{Sentinel}
+that allow the use of the \tcode{-} operator to compute the distance
 between them in constant time.
 
-{\color{oldclr}
-\indexlibrary{\idxcode{SizedIteratorRange}}%
-\begin{itemdecl}
-  template <class I, class S>
-  concept bool SizedIteratorRange() {
-    return Sentinel<S, I>() &&
-      requires (const I i, const S j) {
-        { i - i } -> difference_type_t<I>;
-        { j - j } -> difference_type_t<I>;
-        { i - j } -> difference_type_t<I>;
-        { j - i } -> difference_type_t<I>;
-      };
-  }
-\end{itemdecl}
-
-\pnum
-Let \tcode{a} be a valid iterator of type \tcode{I} and \tcode{b} be
-a valid sentinel of type \tcode{S}. Let \tcode{n} be the smallest value
-of type \tcode{difference_type_t<I>} such that after \tcode{n}
-applications of \tcode{++a}, then \tcode{bool(a == b)}.
-Then \tcode{SizedIteratorRange<I, S>()} is satisfied if and only if:
-
-\begin{itemize}
-\item \tcode{(b - a) == n}.
-\item \tcode{(a - b) == -n}.
-\item \tcode{(a - a) == 0}.
-\item \tcode{(b - b) == 0}.
-\end{itemize}
-} %% color{oldclr}
-
 \indexlibrary{\idxcode{SizedSentinel}}%
-{\color{newclr}
+
 \begin{itemdecl}
   template <class S, class I>
   constexpr bool disable_sized_sentinel = false;
@@ -659,58 +585,13 @@ syntactic requirements but do not in fact satisfy \tcode{SizedSentinel}.
 but do not satisfy \tcode{SizedSentinel} is ill-formed with no diagnostic required
 unless \tcode{disable_sized_sentinel<S, I>} evaluates to
 \tcode{true}~(\ref{structure.requirements}). \exitnote
-} %% color{newclr}
 
 \pnum
-\enternote The \tcode{Sized\oldtxt{IteratorRange}\newtxt{Sentinel}}
+\enternote The \tcode{SizedSentinel}
 concept is satisfied by pairs of
 \tcode{RandomAccessIterator}s~(\ref{iterators.random.access}) and by
 counted iterators and their sentinels~(\ref{counted.iterator}).\exitnote
 
-\ednote{\oldtxt{This concept also gives us a way to demote the category of \tcode{move_iterator}s to Input
-while retaining the ability of \tcode{move_iterator} pairs to communicate the range's size to
-container constructors.}}
-
-{\color{oldclr}
-\rSec2[iterators.olditerator]{(Was) Concept Iterator}
-
-\pnum
-The \tcode{Iterator} concept refines \tcode{WeakIterator}~(\ref{iterators.iterator}) and adds
-the requirement that the iterator is equality comparable.
-
-\pnum
-In the \tcode{Iterator} concept, the set of values over which
-\tcode{==} is (required to be) defined can change over time.
-Each algorithm places additional requirements on the domain of
-\tcode{==} for the iterator values it uses.
-These requirements can be inferred from the uses that algorithm
-makes of \tcode{==} and \tcode{!=}.
-\enterexample
-the call \tcode{find(a, b, x)}
-is defined only if the value of \tcode{a}
-has the property \textit{p}
-defined as follows:
-\tcode{b} has property \textit{p}
-and a value \tcode{i}
-has property \textit{p}
-if
-\tcode{(*i==x)}
-or if
-\tcode{(*i!=x}
-and
-\tcode{++i}
-has property
-\textit{p}).
-\exitexample
-
-\begin{itemdecl}
-  template <class I>
-  concept bool Iterator() {
-    return WeakIterator<I>() &&
-      EqualityComparable<I>();
-  }
-\end{itemdecl}
-} %% color{oldclr}
 \end{addedblock}
 
 \ednote{Section ``Input iterators'' renamed to ``Concept InputIterator'' below:}
@@ -721,64 +602,30 @@ has property
 
 \begin{addedblock}
 \pnum
-The \tcode{\oldtxt{Weak}InputIterator} concept is a refinement of
-\tcode{\oldtxt{Weak}Iterator}~(\ref{iterators.iterator}). It
-defines requirements for a type whose \oldtxt{referred to}\newtxt{referenced} values can be read (from the requirement for
+The \tcode{InputIterator} concept is a refinement of
+\tcode{Iterator}~(\ref{iterators.iterator}). It
+defines requirements for a type whose referenced values can be read (from the requirement for
 \tcode{Readable}~(\ref{iterators.readable})) and which can be both pre- and post-incremented. However,
-\oldtxt{weak }input iterators are not required to be comparable for equality.
+input iterators are not required to be comparable for equality.
 
 \indexlibrary{\idxcode{InputIterator}}%
 \begin{codeblock}
   template <class I>
-  concept bool @\oldtxt{Weak}@InputIterator() {
-    return @\oldtxt{Weak}@Iterator<I>() &&
+  concept bool InputIterator() {
+    return Iterator<I>() &&
       Readable<I>() &&
       requires(I i, const I ci) {
-        typename @\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>;
-        requires DerivedFrom<@\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>, @\oldtxt{weak_}@input_iterator_tag>();
+        typename iterator_category_t<I>;
+        requires DerivedFrom<iterator_category_t<I>, input_iterator_tag>();
         { i++ } -> Readable; // not required to be equality preserving
-        requires Same<@\oldtxt{ValueType}\newtxt{value_type_t}@<I>, @\oldtxt{ValueType}\newtxt{value_type_t}@<decltype(i++)>>();
-        { *ci } -> const @\oldtxt{ValueType}\newtxt{value_type_t}@<I>&;
+        requires Same<value_type_t<I>, value_type_t<decltype(i++)>>();
+        { *ci } -> const value_type_t<I>&;
       };
   }
 \end{codeblock}
 \end{addedblock}
 
-{\color{oldclr}
-\rSec2[iterators.oldinput]{(Was) Concept InputIterator}
-
-\pnum
-The \tcode{InputIterator} concept is a refinement of \tcode{Iterator}~(\ref{iterators.iterator}) and
-\tcode{WeakInputIterator}~(\ref{iterators.input}).
-
-\begin{codeblock}
-  template <class I>
-  concept bool InputIterator() {
-    return WeakInputIterator<I>() &&
-      DerivedFrom<IteratorCategory<I>, input_iterator_tag>() &&
-      Iterator<I>();
-  }
-\end{codeblock}
-
-\pnum
-\enternote
-Since \tcode{InputIterator} is only \tcode{WeaklyIncrementable},
-\tcode{a == b}
-does not imply
-\tcode{++a == ++b}.
-(Equality does not guarantee the substitution property or referential transparency.)
-Algorithms on input iterators should never attempt to pass through the same iterator twice.
-They should be
-\term{single pass}
-algorithms.
-\tcode{value_type_t<I>} is not required
-to be a \tcode{Copyable}
-type~(\ref{concepts.lib.object.copyable}). These algorithms can be used with
-istreams as the source of the input data through the \tcode{istream_iterator} class template.
-\exitnote
-} %% color{oldclr}
-
-\ednote{Section ``Output iterators'' renamed to ``Concept \oldtxt{Weak}OutputIterator'' below:}
+\ednote{Section ``Output iterators'' renamed to ``Concept OutputIterator'' below:}
 
 \rSec2[iterators.output]{Concept OutputIterator}
 
@@ -786,18 +633,18 @@ istreams as the source of the input data through the \tcode{istream_iterator} cl
 
 \begin{addedblock}
 \pnum
-The \tcode{\oldtxt{Weak}OutputIterator} concept is a refinement of
-\tcode{\oldtxt{Weak}Iterator}~(\ref{iterators.iterator}). It defines requirements for a type that
+The \tcode{OutputIterator} concept is a refinement of
+\tcode{Iterator}~(\ref{iterators.iterator}). It defines requirements for a type that
 can be used to write values (from the requirement for
 \tcode{Writable}~(\ref{iterators.writable})) and which can be both pre- and post-incremented.
-However, \oldtxt{weak }output iterators are not required to
+However, output iterators are not required to
 satisfy \tcode{EqualityComparable}.
 
 \indexlibrary{\idxcode{OutputIterator}}%
 \begin{codeblock}
   template <class I, class T>
-  concept bool @\oldtxt{Weak}@OutputIterator() {
-    return @\oldtxt{Weak}@Iterator<I>() && Writable<I, T>();
+  concept bool OutputIterator() {
+    return Iterator<I>() && Writable<I, T>();
   }
 \end{codeblock}
 \end{addedblock}
@@ -813,33 +660,11 @@ They should be
 \term{single pass}
 algorithms.
 \removed{Equality and inequality might not be defined.}
-Algorithms that take \oldtxt{weak }output iterators can be used with ostreams as the destination
+Algorithms that take output iterators can be used with ostreams as the destination
 for placing data through the
 \tcode{ostream_iterator}
 class as well as with insert iterators and insert pointers.
 \exitnote
-
-\begin{addedblock}
-{\color{oldclr}
-\rSec2[iterators.oldoutput]{(Was) Concept OutputIterator}
-
-\pnum
-The \tcode{OutputIterator} concept is a refinement of \tcode{Iterator}~(\ref{iterators.iterator}) and
-\tcode{WeakOutputIterator}~(\ref{iterators.output}).
-
-\begin{codeblock}
-  template <class I, class T>
-  concept bool OutputIterator() {
-    return WeakOutputIterator<I, T>() && Iterator<I>();
-  }
-\end{codeblock}
-
-\pnum
-\enternote Output iterators are used by single-pass
-algorithms that write into a bounded range, like \tcode{generate}.
-\exitnote
-} %% color{oldclr}
-\end{addedblock}
 
 \rSec2[iterators.forward]{Concept ForwardIterator}
 
@@ -868,16 +693,16 @@ are valid and have the indicated semantics, and
 \begin{addedblock}
 \pnum
 The \tcode{ForwardIterator} concept refines \tcode{InputIterator}~(\ref{iterators.input}),
-\oldtxt{and adds}\newtxt{adding equality comparison and} the multi-pass guarantee, described below.
+adding equality comparison and the multi-pass guarantee, described below.
 
 \indexlibrary{\idxcode{ForwardIterator}}%
 \begin{codeblock}
   template <class I>
   concept bool ForwardIterator() {
     return InputIterator<I>() &&
-      DerivedFrom<@\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>, forward_iterator_tag>() &&
-      Incrementable<I>()@\newtxt{ \&\&}@
-      @\newtxt{Sentinel<I, I>()}@;
+      DerivedFrom<iterator_category_t<I>, forward_iterator_tag>() &&
+      Incrementable<I>()&&
+      Sentinel<I, I>();
   }
 \end{codeblock}
 \end{addedblock}
@@ -905,7 +730,7 @@ The requirement that
 \tcode{a == b}
 implies
 \tcode{++a == ++b}
-(which is not true for \removed{input and output}\added{weaker} iterators)
+(which is not true for \changed{input and output}{weaker} iterators)
 and the removal of the restrictions on the number of\removed{ the} assignments through
 a mutable iterator
 (which applies to output iterators)
@@ -944,7 +769,7 @@ and adds the ability to move an iterator backward as well as forward.
   template <class I>
   concept bool BidirectionalIterator() {
     return ForwardIterator<I>() &&
-      DerivedFrom<@\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>, bidirectional_iterator_tag>() &&
+      DerivedFrom<iterator_category_t<I>, bidirectional_iterator_tag>() &&
       requires (I i) {
         { @\dcr@i } -> Same<I&>;
         { i@\dcr@ } -> Same<I>;
@@ -1001,30 +826,20 @@ notation via subscripting.
 
 \indexlibrary{\idxcode{RandomAccessIterator}}%
 \begin{codeblock}
-  @\oldtxt{template <class I>}@
-  @\oldtxt{concept bool \xname{MutableIterator} = // \expos}@
-    @\oldtxt{Iterator<I>() \&\&}@
-    @\oldtxt{requires(const I i) \{}@
-      @\oldtxt{\{ *i \} -> auto\&;}@
-      @\oldtxt{*i = *i;}@
-    @\oldtxt{\};}@
-
   template <class I>
   concept bool RandomAccessIterator() {
     return BidirectionalIterator<I>() &&
-      DerivedFrom<@\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>, random_access_iterator_tag>() &&
-      @\newtxt{Strict}@TotallyOrdered<I>() &&
-      Sized@\oldtxt{IteratorRange}\newtxt{Sentinel}@<I, I>() &&
-      requires (I i, const I j, const @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n) {
+      DerivedFrom<iterator_category_t<I>, random_access_iterator_tag>() &&
+      StrictTotallyOrdered<I>() &&
+      SizedSentinel<I, I>() &&
+      requires (I i, const I j, const difference_type_t<I> n) {
         { i += n } -> Same<I&>;
         { j + n } -> Same<I>;
         { n + j } -> Same<I>;
         { i -= n } -> Same<I&>;
         { j - n } -> Same<I>;
-        { j[n] } -> @\oldtxt{const ValueType<I>\&}\newtxt{Same<reference_t<I>{}>}@;
-      } @\oldtxt{\&\&}@
-      @\oldtxt{(!\xname{MutableIterator}<I> ||}@
-        @\oldtxt{requires(const I i, const DifferenceType<I> n) \{ i[n] = *i; *i = i[n]; \})}@;
+        { j[n] } -> Same<reference_t<I>>;
+      };
   }
 \end{codeblock}
 \end{addedblock}
@@ -1035,7 +850,7 @@ notation via subscripting.
 \pnum
 Let \tcode{a} and \tcode{b} be valid iterators of type \tcode{I} such that \tcode{b} is reachable
 from \tcode{a}. Let \tcode{n} be the smallest value of type
-\tcode{\oldtxt{DifferenceType<I>}}\tcode{\newtxt{difference_type_t<I>}} such that after
+\tcode{difference_type_t<I>} such that after
 \tcode{n} applications of \tcode{++a}, then \tcode{bool(a == b)}. Then
 \tcode{RandomAccessIterator<I>()} is satisfied if and only if:
 
@@ -1066,32 +881,6 @@ objects~(\cxxref{func.require}) as arguments.
 the transition should we ever decide to support proxy iterators in the future. See the
 Future Work appendix~(\ref{future.proxy}).}
 
-{\color{oldclr}
-\rSec2[indirectcallables.as_function_t]{as_function_t type}
-
-\pnum
-The \tcode{\oldtxt{FunctionType}}\tcode{as_function_t} is an alias used to turn a
-callable type~(\cxxref{func.def}) into a function object type~(\ref{function.objects}).
-
-\indexlibrary{\idxcode{function_t}}%
-\begin{codeblock}
-  // Exposition only
-  template <class T>
-    requires is_member_pointer<decay_t<T>>::value
-  auto @\xname{as_function}@(T&& t) {
-    return mem_fn(t);
-  }
-  template <class T>
-  T @\xname{as_function}@(T&& t) {
-    return std::forward<T>(t);
-  }
-
-  template <class T>
-  using @\oldtxt{FunctionType}\newtxt{as_function_t}@ =
-    decltype(@\xname{as_function}@(declval<T>()));
-\end{codeblock}
-} %% color{oldclr}
-
 \rSec2[indirectcallables.indirectfunc]{Indirect callables}
 
 \pnum
@@ -1108,81 +897,69 @@ callable objects~(\cxxref{func.def}) as arguments.
   template <class F, class... Is>
   concept bool IndirectCallable() {
     return (Readable<Is>() && ...) &&
-      @\newtxt{Callable<F, value_type_t<Is>...>();}@
-      @\oldtxt{Function<FunctionType<F>, ValueType<Is>...>();}@
+      Callable<F, value_type_t<Is>...>();
   }
 
   template <class F, class... Is>
   concept bool IndirectRegularCallable() {
     return (Readable<Is>() && ...) &&
-      @\newtxt{RegularCallable<F, value_type_t<Is>...>();}@
-      @\oldtxt{RegularFunction<FunctionType<F>, ValueType<Is>...>();}@
+      RegularCallable<F, value_type_t<Is>...>();
   }
 
   template <class F, class... Is>
   concept bool IndirectCallablePredicate() {
     return (Readable<Is>() && ...) &&
-      @\newtxt{Predicate<F, value_type_t<Is>...>();}@
-      @\oldtxt{Predicate<FunctionType<F>, ValueType<Is>...>();}@
+      Predicate<F, value_type_t<Is>...>();
   }
 
   template <class F, class I1, class I2 = I1>
   concept bool IndirectCallableRelation() {
     return Readable<I1>() && Readable<I2>() &&
-      @\newtxt{Relation<F, value_type_t<I1>, value_type_t<I2>{}>();}@
-      @\oldtxt{Relation<FunctionType<F>, ValueType<I1>, ValueType<I2>{}>();}@
+      Relation<F, value_type_t<I1>, value_type_t<I2>>();
   }
 
   template <class F, class I1, class I2 = I1>
   concept bool IndirectCallableStrictWeakOrder() {
     return Readable<I1>() && Readable<I2>() &&
-      @\newtxt{StrictWeakOrder<F, value_type_t<I1>, value_type_t<I2>{}>();}@
-      @\oldtxt{StrictWeakOrder<FunctionType<F>, ValueType<I1>, ValueType<I2>{}>();}@
+      StrictWeakOrder<F, value_type_t<I1>, value_type_t<I2>>();
   }
 
-  @\oldtxt{template <class F, class... Is>}@
-  @\oldtxt{using IndirectCallableResultType =}@
-    @\oldtxt{ResultType<FunctionType<F>, ValueType<Is>...>}@
+  template <class> struct indirect_result_of { };
+  template <class F, class... Is>
+    requires IndirectCallable<remove_reference_t<F>, Is...>()
+  struct indirect_result_of<F(Is...)> :
+    result_of<F(value_type_t<Is>...)> { };
 
-  @\newtxt{template <class> struct indirect_result_of \{ \};}@
-  @\newtxt{template <class F, class... Is>}@
-    @\newtxt{requires IndirectCallable<remove_reference_t<F>, Is...>()}@
-  @\newtxt{struct indirect_result_of<F(Is...)> :}@
-    @\newtxt{result_of<F(value_type_t<Is>...)> \{ \};}@
-
-  @\newtxt{template <class F>}@
-  @\newtxt{using indirect_result_of_t = typename indirect_result_of<F>::type;}@
+  template <class F>
+  using indirect_result_of_t = typename indirect_result_of<F>::type;
 \end{codeblock}
 
 \rSec2[projected]{Class template \tcode{projected}}
 
 \pnum
-The \tcode{\oldtxt{P}\newtxt{p}rojected} class template is intended for use when specifying the constraints of
+The \tcode{projected} class template is intended for use when specifying the constraints of
 algorithms that accept callable objects and projections. It bundles a \tcode{Readable} type
 \tcode{I} and a function \tcode{Proj} into a new \tcode{Readable} type whose
 \tcode{reference} type is the result of applying \tcode{Proj} to the
-\tcode{\oldtxt{ReferenceType}}\tcode{\newtxt{reference_t}} of \tcode{I}.
+\tcode{reference_t} of \tcode{I}.
 
 \indexlibrary{\idxcode{projected}}%
 \begin{codeblock}
   template <Readable I, IndirectRegularCallable<I> Proj>
-    @\oldtxt{requires RegularFunction<FunctionType<Proj>, ValueType<I>{}>}@
-    @\newtxt{requires RegularCallable<Proj, reference_t<I>{}>()}@
-  struct @\oldtxt{P}\newtxt{p}@rojected {
-    @\oldtxt{using value_type = decay_t<ResultType<FunctionType<Proj>, ValueType<I>{}>{}>;}@
-    @\oldtxt{ResultType<FunctionType<Proj>, ReferenceType<I>{}> operator*() const;}@
-    @\newtxt{using value_type = decay_t<indirect_result_of_t<Proj\&(I)>{}>;}@
-    @\newtxt{result_of_t<Proj\&(reference_t<I>)> operator*() const;}@
+    requires RegularCallable<Proj, reference_t<I>>()
+  struct projected {
+    using value_type = decay_t<indirect_result_of_t<Proj&(I)>>;
+    result_of_t<Proj&(reference_t<I>)> operator*() const;
   };
 
   template <WeaklyIncrementable I, class Proj>
-  struct difference_type<@\oldtxt{P}\newtxt{p}@rojected<I, Proj>> {
-    using type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
+  struct difference_type<projected<I, Proj>> {
+    using type = difference_type_t<I>;
   };
 \end{codeblock}
 
 \pnum
-\enternote \tcode{\oldtxt{P}\newtxt{p}rojected} is only used to ease constraints specification. Its
+\enternote \tcode{projected} is only used to ease constraints specification. Its
 member function need not be defined.\exitnote
 
 \rSec1[commonalgoreq]{Common algorithm requirements}
@@ -1191,56 +968,40 @@ member function need not be defined.\exitnote
 
 \pnum
 There are several additional iterator concepts that are commonly applied to families of algorithms.
-These group together iterator requirements of algorithm families. \newtxt{There are three relational
+These group together iterator requirements of algorithm families. There are three relational
 concepts that specify how element values are transferred between \tcode{Readable} and \tcode{Writable} types:
-\tcode{IndirectlyMovable}, \tcode{IndirectlyCopyable}, and \tcode{IndirectlySwappable}.} There are \oldtxt{four}\newtxt{three} relational concepts
-for rearrangements: \tcode{Permutable}, \tcode{Mergeable},\oldtxt{ \tcode{MergeMovable},} and \tcode{Sortable}.
+\tcode{IndirectlyMovable}, \tcode{IndirectlyCopyable}, and \tcode{IndirectlySwappable}. There are three relational concepts
+for rearrangements: \tcode{Permutable}, \tcode{Mergeable}, and \tcode{Sortable}.
 There is one relational concept for comparing values from different sequences: \tcode{IndirectlyComparable}.
 
-{\color{newclr}
 \pnum
 \enternote The \tcode{equal_to<>} and \tcode{less<>}~(\ref{comparisons}) function types used in the
 concepts below impose additional constraints on their arguments beyond those that appear explicitly in the
 concepts' bodies. \tcode{equal_to<>} requires its arguments satisfy \tcode{EqualityComparable}~(\ref{concepts.lib.compare.equalitycomparable}),
 and \tcode{less<>} requires its arguments satisfy \tcode{StrictTotallyOrdered}~(\ref{concepts.lib.compare.stricttotallyordered}).\exitnote
-}
 
 \rSec2[commonalgoreq.indirectlymovable]{Concept IndirectlyMovable}
 
 \pnum
-The \tcode{IndirectlyMovable} concept \oldtxt{describes}\newtxt{specifies} the\oldtxt{ move} relationship between a \tcode{Readable}
-type and a \tcode{\oldtxt{Move}Writable} type\newtxt{ between which values may be moved}.
+The \tcode{IndirectlyMovable} concept specifies the relationship between a \tcode{Readable}
+type and a \tcode{Writable} type between which values may be moved.
 
 \indexlibrary{\idxcode{IndirectlyMovable}}%
 \begin{codeblock}
-  @\newtxt{template <class I>}@
-  @\newtxt{using rvalue_reference_t =}@
-    @\newtxt{decltype(std::move(declval<reference_t<I>{>}()));}@
+  template <class I>
+  using rvalue_reference_t =
+    decltype(std::move(declval<reference_t<I>>()));
 
-  template <class I@\newtxt{n}@, class Out>
+  template <class In, class Out>
   concept bool IndirectlyMovable() {
-    return Readable<I@\newtxt{n}@>() &&
-      @\oldtxt{Move}@Writable<Out, @\oldtxt{ValueType<I>}\newtxt{rvalue_reference_t<In>}@>();
+    return Readable<In>() &&
+      Writable<Out, rvalue_reference_t<In>>();
   }
 \end{codeblock}
 
 \ednote{This is a simple version of \tcode{rvalue_reference_t} to be replaced
 with the formulation from P0022 when that proposal is integrated.}
 
-{\color{oldclr} %% Redundant with Writable
-\pnum
-Let \tcode{i} be an object of type \tcode{I}, and let \tcode{o} be a
-dereferenceable object of type \tcode{Out}. Then
-\tcode{IndirectlyMovable<I, Out>()} is satisfied if and only if
-
-\begin{itemize}
-\item If \tcode{Out} is \tcode{Readable}, after the assignment
-\tcode{*o = std::move(*i)}, \tcode{*o} is equal to
-the value of \tcode{*i} before the assignment.
-\end{itemize}
-} %% color{oldclr}
-
-{\color{newclr}
 \pnum
 The \tcode{IndirectlyMovableStorable} concept augments \tcode{IndirectlyMovable} with additional
 requirements enabling the transfer to be performed through an intermediate object of the
@@ -1257,36 +1018,22 @@ requirements enabling the transfer to be performed through an intermediate objec
       Assignable<value_type_t<In>&, rvalue_reference_t<In>>();
   }
 \end{codeblock}
-} %% color{newclr}
 
 \rSec2[commonalgoreq.indirectlycopyable]{Concept IndirectlyCopyable}
 
 \pnum
-The \tcode{IndirectlyCopyable} concept \oldtxt{describes}\newtxt{specifies} the\oldtxt{ copy} relationship between a \tcode{Readable}
-type and a \tcode{Writable} type\newtxt{ between which values may be transferred without necessarily moving}.
+The \tcode{IndirectlyCopyable} concept specifies the relationship between a \tcode{Readable}
+type and a \tcode{Writable} type between which values may be transferred without necessarily moving.
 
 \indexlibrary{\idxcode{IndirectlyCopyable}}%
 \begin{codeblock}
-  template <class I@\newtxt{n}@, class Out>
+  template <class In, class Out>
   concept bool IndirectlyCopyable() {
-    return IndirectlyMovable<I@\newtxt{n}@, Out>() &&
-      Writable<Out, @\oldtxt{ValueType}\newtxt{reference_t}@<I@\newtxt{n}@>>();
+    return IndirectlyMovable<In, Out>() &&
+      Writable<Out, reference_t<In>>();
   }
 \end{codeblock}
 
-{\color{oldclr} %% Redundant with Writable
-\pnum
-Let \tcode{i} be an object of type \tcode{I}, and let \tcode{o} be a
-dereferenceable object of type \tcode{Out}. Then
-\tcode{IndirectlyCopyable<I, Out>()} is satisfied if and only if
-
-\begin{itemize}
-\item If \tcode{Out} is \tcode{Readable}, after the assignment \tcode{*o = *i},
-\tcode{*o} is equal to the value of \tcode{*i}.
-\end{itemize}
-} %% color{oldclr}
-
-{\color{newclr}
 \pnum
 The \tcode{IndirectlyCopyableStorable} concept augments \tcode{IndirectlyCopyable} with additional
 requirements enabling the transfer to be performed through an intermediate object of the
@@ -1304,7 +1051,6 @@ requirements enabling the transfer to be performed through an intermediate objec
       Assignable<value_type_t<In>&, reference_t<In>>();
   }
 \end{codeblock}
-} %% color{newclr}
 
 \rSec2[commonalgoreq.indirectlyswappable]{Concept IndirectlySwappable}
 
@@ -1317,7 +1063,7 @@ reference types of two \tcode{Readable} types.
   template <class I1, class I2 = I1>
   concept bool IndirectlySwappable() {
     return Readable<I1>() && Readable<I2>() &&
-      Swappable<@\oldtxt{ReferenceType}\newtxt{reference_t}@<I1>, @\oldtxt{ReferenceType}\newtxt{reference_t}@<I2>>();
+      Swappable<reference_t<I1>, reference_t<I2>>();
   }
 \end{codeblock}
 
@@ -1332,7 +1078,7 @@ compare values from two different sequences.
   template <class I1, class I2, class R = equal_to<>, class P1 = identity,
     class P2 = identity>
   concept bool IndirectlyComparable() {
-    return IndirectCallableRelation<R, @\oldtxt{P}\newtxt{p}@rojected<I1, P1>, @\oldtxt{P}\newtxt{p}@rojected<I2, P2>>();
+    return IndirectCallableRelation<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
 
@@ -1347,9 +1093,8 @@ elements in place by moving or swapping them.
   template <class I>
   concept bool Permutable() {
     return ForwardIterator<I>() &&
-      @\oldtxt{Movable<ValueType<I>{>}() \&\&}@
-      IndirectlyMovable@\newtxt{Storable}@<I, I>()@\newtxt{ \&\&}@
-      @\newtxt{IndirectlySwappable<I, I>()}@;
+      IndirectlyMovableStorable<I, I>() &&
+      IndirectlySwappable<I, I>();
   }
 \end{codeblock}
 
@@ -1369,75 +1114,39 @@ algorithms that merge sorted sequences into an output sequence by copying elemen
       WeaklyIncrementable<Out>() &&
       IndirectlyCopyable<I1, Out>() &&
       IndirectlyCopyable<I2, Out>() &&
-      IndirectCallableStrictWeakOrder<R, @\oldtxt{P}\newtxt{p}@rojected<I1, P1>, @\oldtxt{P}\newtxt{p}@rojected<I2, P2>>();
+      IndirectCallableStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
-
-\oldtxt{
-\pnum
-\enternote When \tcode{less<>} is used as the
-relation, the value type must satisfy \tcode{TotallyOrdered}.\exitnote
-}
-
-{\color{oldclr}
-\rSec2[commonalgoreq.mergemovable]{Concept MergeMovable}
-
-\pnum
-The \tcode{MergeMovable} concept specifies the requirements of
-algorithms that merge sorted sequences into an output sequence by moving elements.
-
-\indexlibrary{\idxcode{MergeMovable}}%
-\begin{codeblock}
-  template <class I1, class I2, class Out,
-      class R = less<>, class P1 = identity, class P2 = identity>
-  concept bool MergeMovable() {
-    return InputIterator<I1>() &&
-      InputIterator<I2>() &&
-      WeaklyIncrementable<Out>() &&
-      IndirectlyMovable<I1, Out>() &&
-      IndirectlyMovable<I2, Out>() &&
-      IndirectCallableStrictWeakOrder<R, Projected<I1, P1>, Projected<I2, P2>>();
-  }
-\end{codeblock}
-
-\pnum
-\enternote When \tcode{less<>} is used as the
-relation, the value type must satisfy \tcode{TotallyOrdered}.\exitnote
-} %% color{oldclr}
 
 \rSec2[commonalgoreq.sortable]{Concept Sortable}
 
 \pnum
 The \tcode{Sortable} concept specifies the common requirements of algorithms that permute
-sequences\oldtxt{ of iterators} into\oldtxt{ an} ordered sequence\newtxt{s} (e.g., \tcode{sort}).
+sequences into ordered sequences (e.g., \tcode{sort}).
 
 \indexlibrary{\idxcode{Sortable}}%
 \begin{codeblock}
   template <class I, class R = less<>, class P = identity>
   concept bool Sortable() {
     return Permutable<I>() &&
-      IndirectCallableStrictWeakOrder<R, @\oldtxt{P}\newtxt{p}@rojected<I, P>>();
+      IndirectCallableStrictWeakOrder<R, projected<I, P>>();
   }
 \end{codeblock}
 
-\oldtxt{
-\pnum
-\enternote When \tcode{less<>} is used as the
-relation, the value type must satisfy \tcode{TotallyOrdered}.\exitnote
-}
 \end{addedblock}
 
 \rSec1[iterator.synopsis]{Header \tcode{<experimental/ranges/iterator>} synopsis}
 
-\indexlibrary{\idxhdr{experimental/ranges\oldtxt{_v1}/iterator}}%
+\indexlibrary{\idxhdr{experimental/ranges/iterator}}%
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   // \ref{iterator.primitives}, primitives:
   template<class Iterator> @\changed{struct}{using}@ iterator_traits@\added{ = \seebelow}@;
   @\removed{template<class T> struct iterator_traits<T*>;}@
+  
+  @\removed{template<class Category, class T, class Distance = ptrdiff_t,}@
+       @\removed{class Pointer = T*, class Reference = T\&> struct iterator;}@
 
-  @\oldtxt{template<class Category, class T, class Distance = ptrdiff_t,}@
-       @\oldtxt{class Pointer = T*, class Reference = T\&> struct iterator;}@
 \end{codeblock}
 
 \begin{addedblock}
@@ -1445,22 +1154,21 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   template <class> struct difference_type;
   template <class> struct value_type;
   template <class> struct iterator_category;
-  template <class @\oldtxt{WeaklyIncrementable}\newtxt{T}@> using @\oldtxt{DifferenceType}\newtxt{difference_type_t}@
-    = typename difference_type<@\oldtxt{WeaklyIncrementable}\newtxt{T}@>::type;
-  template <class @\oldtxt{Readable}\newtxt{T}@> using @\oldtxt{ValueType}\newtxt{value_type_t}@
-    = typename value_type<@\oldtxt{Readable}\newtxt{T}@>::type;
-  template <class @\oldtxt{WeakInputIterator}\newtxt{T}@> using @\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@
-    = typename iterator_category<@\oldtxt{WeakInputIterator}\newtxt{T}@>::type;
+  template <class T> using difference_type_t
+    = typename difference_type<T>::type;
+  template <class T> using value_type_t
+    = typename value_type<T>::type;
+  template <class T> using iterator_category_t
+    = typename iterator_category<T>::type;
 
 \end{codeblock}
 \end{addedblock}
 \begin{codeblock}
   struct output_iterator_tag { };
-  @\oldtxt{struct weak_input_iterator_tag \{ \};}@
-  struct input_iterator_tag @\oldtxt{: public weak_input_iterator_tag }@{ };
-  struct forward_iterator_tag :@\oldoldtxt{ public}@ input_iterator_tag { };
-  struct bidirectional_iterator_tag :@\oldoldtxt{ public}@ forward_iterator_tag { };
-  struct random_access_iterator_tag :@\oldoldtxt{ public}@ bidirectional_iterator_tag { };
+  struct input_iterator_tag { };
+  struct forward_iterator_tag :@\removed{ public}@ input_iterator_tag { };
+  struct bidirectional_iterator_tag :@\removed{ public}@ forward_iterator_tag { };
+  struct random_access_iterator_tag :@\removed{ public}@ bidirectional_iterator_tag { };
 
   // \ref{iterator.operations}, iterator operations:
 \end{codeblock}
@@ -1481,24 +1189,24 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
 \end{removedblock}
 \begin{addedblock}
 \begin{codeblock}
-  template <@\oldtxt{Weak}@Iterator I>
-    void advance(I& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+  template <Iterator I>
+    void advance(I& i, difference_type_t<I> n);
   template <Iterator I, Sentinel<I> S>
     void advance(I& i, S bound);
   template <Iterator I, Sentinel<I> S>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> advance(I& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, S bound);
+    difference_type_t<I> advance(I& i, difference_type_t<I> n, S bound);
   template <Iterator I, Sentinel<I> S>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> distance(I first, S last);
-  template <@\oldtxt{Weak}@Iterator I>
-    I next(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n = 1);
+    difference_type_t<I> distance(I first, S last);
+  template <Iterator I>
+    I next(I x, difference_type_t<I> n = 1);
   template <Iterator I, Sentinel<I> S>
     I next(I x, S bound);
   template <Iterator I, Sentinel<I> S>
-    I next(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, S bound);
+    I next(I x, difference_type_t<I> n, S bound);
   template <BidirectionalIterator I>
-    I prev(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n = 1);
+    I prev(I x, difference_type_t<I> n = 1);
   template <BidirectionalIterator I>
-    I prev(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, I bound);
+    I prev(I x, difference_type_t<I> n, I bound);
 \end{codeblock}
 \end{addedblock}
 
@@ -1508,51 +1216,50 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   @\added{\itshape{\rmfamily{// \ref{iterators.reverse} Reverse iterators}}}@
   template <@\changed{class Iterator}{BidirectionalIterator I}@> class reverse_iterator;
 
-  template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator==(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  @\newnewtxt{template <class I1, class I2>}@
-      @\newnewtxt{requires EqualityComparable<I1, I2>()}@
-    @\newnewtxt{bool operator!=(}@
-      @\newnewtxt{const reverse_iterator<I1>\& x,}@
-      @\newnewtxt{const reverse_iterator<I2>\& y);}@
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  @\added{template <class I1, class I2>}@
+      @\added{requires EqualityComparable<I1, I2>()}@
+    @\added{bool operator!=(}@
+      @\added{const reverse_iterator<I1>\& x,}@
+      @\added{const reverse_iterator<I2>\& y);}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  @\oldoldtxt{template <class Iterator1, class Iterator2>}@
-      @\oldtxt{requires EqualityComparable<I1, I2>()}@
-    @\oldoldtxt{bool operator!=(}@
-      @\oldoldtxt{const reverse_iterator<Iterator1>\& x,}@
-      @\oldoldtxt{const reverse_iterator<Iterator2>\& y);}@
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  @\removed{template <class Iterator1, class Iterator2>}@
+    @\removed{bool operator!=(}@
+      @\removed{const reverse_iterator<Iterator1>\& x,}@
+      @\removed{const reverse_iterator<Iterator2>\& y);}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>=(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<=(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
 
-  template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
-      @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-    @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires SizedSentinel<I1, I2>()}@
+    @\changed{auto}{difference_type_t<I2>}@ operator-(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
   template <@\changed{class Iterator}{RandomAccessIterator I}@>
     reverse_iterator<@\changed{Iterator}{I}@>
       operator+(
-    @\removed{typename reverse_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newnewtxt{difference_type_t<I>}@ n,
+    @\changed{typename reverse_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
     const reverse_iterator<@\changed{Iterator}{I}@>& x);
 
   template <@\changed{class Iterator}{BidirectionalIterator I}@>
@@ -1570,222 +1277,170 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   template <class Container> class insert_iterator;
   template <class Container>
     insert_iterator<Container> inserter(Container& x, @\removed{typename Container::iterator}@
-      @\oldtxt{IteratorType}\newtxt{iterator_t}\added{<Container>}@ i);
+      @iterator_t\added{<Container>}@ i);
 
   @\added{\itshape{\rmfamily{// \ref{iterators.move} Move iterators}}}@
-  template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@> class move_iterator;
-  template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+  template <@\changed{class Iterator}{InputIterator I}@> class move_iterator;
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator==(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator!=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 
-  template <class @\removed{Iterator1}\oldtxt{WeakInputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{WeakInputIterator }\added{I2}@>
-      @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-    @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires SizedSentinel<I1, I2>()}@
+    @\changed{auto}{difference_type_t<I2>}@ operator-(
       const move_iterator<@\changed{Iterator1}{I1}@>& x,
       const move_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
   template <@\changed{class Iterator}{RandomAccessIterator I}@>
     move_iterator<@\changed{Iterator}{I}@>
       operator+(
-    @\removed{typename move_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newnewtxt{difference_type_t<I>}@ n,
+    @\changed{typename move_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
     const move_iterator<@\changed{Iterator}{I}@>& x);
-  template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@>
+  template <@\changed{class Iterator}{InputIterator I}@>
     move_iterator<@\changed{Iterator}{I}@> make_move_iterator(@\changed{Iterator}{I}@ i);
 \end{codeblock}
 
 \begin{addedblock}
 \begin{codeblock}
-  @\newtxt{template <Semiregular S> class move_sentinel;}@
-  @\newtxt{template <class I, Sentinel<I> S>}@
-    @\newtxt{bool operator==(}@
-      @\newtxt{const move_iterator<I>\& i, const move_sentinel<S>\& s);}@
-  @\newtxt{template <class I, Sentinel<I> S>}@
-    @\newtxt{bool operator==(}@
-      @\newtxt{const move_sentinel<S>\& s, const move_iterator<I>\& i);}@
-  @\newtxt{template <class I, Sentinel<I> S>}@
-    @\newtxt{bool operator!=(}@
-      @\newtxt{const move_iterator<I>\& i, const move_sentinel<S>\& s);}@
-  @\newtxt{template <class I, Sentinel<I> S>}@
-    @\newtxt{bool operator!=(}@
-      @\newtxt{const move_sentinel<S>\& s, const move_iterator<I>\& i);}@
+  template <Semiregular S> class move_sentinel;
+  template <class I, Sentinel<I> S>
+    bool operator==(
+      const move_iterator<I>& i, const move_sentinel<S>& s);
+  template <class I, Sentinel<I> S>
+    bool operator==(
+      const move_sentinel<S>& s, const move_iterator<I>& i);
+  template <class I, Sentinel<I> S>
+    bool operator!=(
+      const move_iterator<I>& i, const move_sentinel<S>& s);
+  template <class I, Sentinel<I> S>
+    bool operator!=(
+      const move_sentinel<S>& s, const move_iterator<I>& i);
 
-  @\newtxt{template <class I, SizedSentinel<I> S>}@
-    @\newtxt{difference_type_t<I> operator-(}@
-      @\newtxt{const move_sentinel<S>\& s, const move_iterator<I>\& i);}@
-  @\newtxt{template <class I, SizedSentinel<I> S>}@
-    @\newtxt{difference_type_t<I> operator-(}@
-      @\newtxt{const move_iterator<I>\& i, const move_sentinel<S>\& s);}@
+  template <class I, SizedSentinel<I> S>
+    difference_type_t<I> operator-(
+      const move_sentinel<S>& s, const move_iterator<I>& i);
+  template <class I, SizedSentinel<I> S>
+    difference_type_t<I> operator-(
+      const move_iterator<I>& i, const move_sentinel<S>& s);
 
-  @\newtxt{template <Semiregular S>}@
-    @\newtxt{move_sentinel<S> make_move_sentinel(S s);}@
+  template <Semiregular S>
+    move_sentinel<S> make_move_sentinel(S s);
 
   // \ref{iterators.common} Common iterators
-  @\oldtxt{template<class A, class B>}@
-  @\oldtxt{concept bool \xname{WeaklyEqualityComparable} = \seebelow;  // \expos}@
-  @\oldtxt{template<class S, class I>}@
-  @\oldtxt{concept bool \xname{WeakSentinel} = \seebelow;              // \expos}@
 
-  template <@\oldtxt{Input}@Iterator I, @\oldtxt{\xname{Weak}}@Sentinel<I> S>
-    @\newtxt{requires !Same<I, S>()}@
+  template <Iterator I, Sentinel<I> S>
+    requires !Same<I, S>()
   class common_iterator;
 
-  @\newtxt{template <Readable I, class S>}@
-  @\newtxt{struct value_type<common_iterator<I, S>{>};}@
+  template <Readable I, class S>
+  struct value_type<common_iterator<I, S>>;
 
-  @\newtxt{template <InputIterator I, class S>}@
-  @\newtxt{struct iterator_category<common_iterator<I, S>{>};}@
-  @\newtxt{template <ForwardIterator I, class S>}@
-  @\newtxt{struct iterator_category<common_iterator<I, S>{>};}@
+  template <InputIterator I, class S>
+  struct iterator_category<common_iterator<I, S>>;
+  template <ForwardIterator I, class S>
+  struct iterator_category<common_iterator<I, S>>;
 
-  @\newtxt{template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>}@
-  @\newtxt{bool operator==(}@
-    @\newtxt{const common_iterator<I1, S1>\& x, const common_iterator<I2, S2>\& y);}@
-  template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-    requires EqualityComparable<I1, I2>()@\oldtxt{ \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-      @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
   bool operator==(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
-  template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-    @\oldtxt{requires EqualityComparable<I1, I2>() \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-      @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
+    requires EqualityComparable<I1, I2>()
+  bool operator==(
+    const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
   bool operator!=(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 
-  @\oldtxt{template <class I1, class S1, class I2, class S2>}@
-    @\oldtxt{requires SizedIteratorRange<I1, I1>() \&\& SizedIteratorRange<I2, I2>() \&\&}@
-      @\oldtxt{requires (const I1 i1, const S1 s1, const I2 i2, const S2 s2) \{}@
-        @\oldtxt{\{i1-i2\}->DifferenceType<I2>; \{i2-i1\}->DifferenceType<I2>;}@
-        @\oldtxt{\{i1-s2\}->DifferenceType<I2>; \{s2-i1\}->DifferenceType<I2>;}@
-        @\oldtxt{\{i2-s1\}->DifferenceType<I2>; \{s1-i2\}->DifferenceType<I2>;}@
-      @\oldtxt{\}}@
-  @\newtxt{template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>}@
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+  template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>
+  difference_type_t<I2> operator-(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 
   // \ref{default.sentinels} Default sentinels
   class default_sentinel;
-  @\oldtxt{constexpr bool operator==(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr bool operator!=(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr bool operator<(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr bool operator<=(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr bool operator>(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr bool operator>=(default_sentinel x, default_sentinel y) noexcept;}@
-  @\oldtxt{constexpr ptrdiff_t operator-(default_sentinel x, default_sentinel y) noexcept;}@
-
   // \ref{iterators.counted} Counted iterators
-  template <@\oldtxt{Weak}@Iterator I> class counted_iterator;
+  template <Iterator I> class counted_iterator;
 
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator==(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
     bool operator==(
-      const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel@\oldtxt{ y}@);
-  @\oldtxt{template <WeakIterator I>}@
+      const counted_iterator<auto>& x, default_sentinel);
     bool operator==(
-      default_sentinel@\oldtxt{ x}@, const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& @\oldtxt{y}\newtxt{x}@);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+      default_sentinel, const counted_iterator<auto>& x);
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator!=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
     bool operator!=(
-      const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel y);
-  @\oldtxt{template <WeakIterator I>}@
+      const counted_iterator<auto>& x, default_sentinel y);
     bool operator!=(
-      default_sentinel x, const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& y);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+      default_sentinel x, const counted_iterator<auto>& y);
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator<(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator<=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<=(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<=(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator>(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator>=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>=(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>=(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+    difference_type_t<I2> operator-(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+  template <class I>
+    difference_type_t<I> operator-(
       const counted_iterator<I>& x, default_sentinel y);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+  template <class I>
+    difference_type_t<I> operator-(
       default_sentinel x, const counted_iterator<I>& y);
   template <RandomAccessIterator I>
     counted_iterator<I>
-      operator+(@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, const counted_iterator<I>& x);
-  template <@\oldtxt{Weak}@Iterator I>
-    counted_iterator<I> make_counted_iterator(I i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+      operator+(difference_type_t<I> n, const counted_iterator<I>& x);
+  template <Iterator I>
+    counted_iterator<I> make_counted_iterator(I i, difference_type_t<I> n);
 
-  template <@\oldtxt{Weak}@Iterator I>
-    void advance(counted_iterator<I>& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+  template <Iterator I>
+    void advance(counted_iterator<I>& i, difference_type_t<I> n);
 
   // \ref{unreachable.sentinels} Unreachable sentinels
-  @\oldtxt{struct}\newtxt{class}@ unreachable@\oldtxt{\{ \}}@;
+  class unreachable;
   template <Iterator I>
     constexpr bool operator==(const I&, unreachable) noexcept;
   template <Iterator I>
     constexpr bool operator==(unreachable, const I&) noexcept;
-  @\oldtxt{constexpr bool operator==(unreachable, unreachable) noexcept;}@
   template <Iterator I>
     constexpr bool operator!=(const I&, unreachable) noexcept;
   template <Iterator I>
     constexpr bool operator!=(unreachable, const I&) noexcept;
-  @\oldtxt{constexpr bool operator!=(unreachable, unreachable) noexcept;}@
 
   // \ref{dangling.wrappers} Dangling wrapper
   template <class T> class dangling;
@@ -1799,21 +1454,21 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   template <class T, class charT, class traits, class Distance>
     bool operator==(const istream_iterator<T, charT, traits, Distance>& x,
             const istream_iterator<T, charT, traits, Distance>& y);
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator==(default_sentinel x,}@
-            @\newtxt{const istream_iterator<T, charT, traits, Distance>\& y);}@
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator==(const istream_iterator<T, charT, traits, Distance>\& x,}@
-            @\newtxt{default_sentinel y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator==(default_sentinel x,}@
+            @\added{const istream_iterator<T, charT, traits, Distance>\& y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator==(const istream_iterator<T, charT, traits, Distance>\& x,}@
+            @\added{default_sentinel y);}@
   template <class T, class charT, class traits, class Distance>
     bool operator!=(const istream_iterator<T, charT, traits, Distance>& x,
             const istream_iterator<T, charT, traits, Distance>& y);
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator!=(default_sentinel x,}@
-            @\newtxt{const istream_iterator<T, charT, traits, Distance>\& y);}@
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
-            @\newtxt{default_sentinel y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator!=(default_sentinel x,}@
+            @\added{const istream_iterator<T, charT, traits, Distance>\& y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
+            @\added{default_sentinel y);}@
 
   template <class T, class charT = char, class traits = char_traits<charT>>
       class ostream_iterator;
@@ -1823,21 +1478,21 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   template <class charT, class traits>
     bool operator==(const istreambuf_iterator<charT, traits>& a,
             const istreambuf_iterator<charT, traits>& b);
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator==(default_sentinel a,}@
-            @\newtxt{const istreambuf_iterator<charT, traits>\& b);}@
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator==(const istreambuf_iterator<charT, traits>\& a,}@
-            @\newtxt{default_sentinel b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator==(default_sentinel a,}@
+            @\added{const istreambuf_iterator<charT, traits>\& b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator==(const istreambuf_iterator<charT, traits>\& a,}@
+            @\added{default_sentinel b);}@
   template <class charT, class traits>
     bool operator!=(const istreambuf_iterator<charT, traits>& a,
             const istreambuf_iterator<charT, traits>& b);
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator!=(default_sentinel a,}@
-            @\newtxt{const istreambuf_iterator<charT, traits>\& b);}@
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
-            @\newtxt{default_sentinel b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator!=(default_sentinel a,}@
+            @\added{const istreambuf_iterator<charT, traits>\& b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
+            @\added{default_sentinel b);}@
 
   template <class charT, class traits = char_traits<charT> >
     class ostreambuf_iterator;
@@ -1849,90 +1504,69 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
   @\removed{template <class C> auto end(const C\& c) -> decltype(c.end());}@
   @\removed{template <class T, size_t N> constexpr T* begin(T (\&array)[N]) noexcept;}@
   @\removed{template <class T, size_t N> constexpr T* end(T (\&array)[N]) noexcept;}@
-  @\oldtxt{using std::begin;}@
-  @\oldtxt{using std::end;}@
-  @\oldtxt{template <class>}@
-    @\oldtxt{concept bool _Auto = true; // \expos}@
-  @\oldoldtxt{template <class C> constexpr auto cbegin(const C\& c) noexcept(noexcept(std::begin(c)))}@
-    @\oldoldtxt{-> decltype(std::begin(c));}@
-  @\oldoldtxt{template <class C> constexpr auto cend(const C\& c) noexcept(noexcept(std::end(c)))}@
-    @\oldoldtxt{-> decltype(std::end(c));}@
-  @\oldoldtxt{template <class C> auto rbegin(C\& c) -> decltype(c.rbegin());}@
-  @\oldoldtxt{template <class C> auto rbegin(const C\& c) -> decltype(c.rbegin());}@
-  @\oldoldtxt{template <class C> auto rend(C\& c) -> decltype(c.rend());}@
-  @\oldoldtxt{template <class C> auto rend(const C\& c) -> decltype(c.rend());}@
-  @\oldoldtxt{template <class T, size_t N> reverse_iterator<T*> rbegin(T (\&array)[N]);}@
-  @\oldoldtxt{template <class T, size_t N> reverse_iterator<T*> rend(T (\&array)[N]);}@
-  @\oldoldtxt{template <class E> reverse_iterator<const E*> rbegin(initializer_list<E> il);}@
-  @\oldoldtxt{template <class E> reverse_iterator<const E*> rend(initializer_list<E> il);}@
-  @\oldoldtxt{template <class C> auto crbegin(const C\& c) -> decltype(std::rbegin(c));}@
-  @\oldoldtxt{template <class C> auto crend(const C\& c) -> decltype(std::rend(c));}@
+  @\removed{template <class C> constexpr auto cbegin(const C\& c) noexcept(noexcept(std::begin(c)))}@
+    @\removed{-> decltype(std::begin(c));}@
+  @\removed{template <class C> constexpr auto cend(const C\& c) noexcept(noexcept(std::end(c)))}@
+    @\removed{-> decltype(std::end(c));}@
+  @\removed{template <class C> auto rbegin(C\& c) -> decltype(c.rbegin());}@
+  @\removed{template <class C> auto rbegin(const C\& c) -> decltype(c.rbegin());}@
+  @\removed{template <class C> auto rend(C\& c) -> decltype(c.rend());}@
+  @\removed{template <class C> auto rend(const C\& c) -> decltype(c.rend());}@
+  @\removed{template <class T, size_t N> reverse_iterator<T*> rbegin(T (\&array)[N]);}@
+  @\removed{template <class T, size_t N> reverse_iterator<T*> rend(T (\&array)[N]);}@
+  @\removed{template <class E> reverse_iterator<const E*> rbegin(initializer_list<E> il);}@
+  @\removed{template <class E> reverse_iterator<const E*> rend(initializer_list<E> il);}@
+  @\removed{template <class C> auto crbegin(const C\& c) -> decltype(std::rbegin(c));}@
+  @\removed{template <class C> auto crend(const C\& c) -> decltype(std::rend(c));}@
 \end{codeblock}
 \begin{addedblock}
 \begin{codeblock}
-  @\oldtxt{template <class C> auto size(const C\& c) -> decltype(c.size());}@
-  @\oldtxt{template <class T, size_t N> constexpr size_t size(T (\&array)[N]) noexcept;}@
-  @\oldtxt{template <class E> size_t size(initializer_list<E> il) noexcept;}@
-  @\newtxt{namespace \{}@
-    @\newtxt{constexpr \unspec begin = \unspec;}@
-    @\newtxt{constexpr \unspec end = \unspec;}@
-    @\newtxt{constexpr \unspec cbegin = \unspec;}@
-    @\newtxt{constexpr \unspec cend = \unspec;}@
-    @\newtxt{constexpr \unspec rbegin = \unspec;}@
-    @\newtxt{constexpr \unspec rend = \unspec;}@
-    @\newtxt{constexpr \unspec crbegin = \unspec;}@
-    @\newtxt{constexpr \unspec crend = \unspec;}@
-  @\newtxt{\}}@
+  namespace {
+    constexpr @\unspec@ begin = @\unspec@;
+    constexpr @\unspec@ end = @\unspec@;
+    constexpr @\unspec@ cbegin = @\unspec@;
+    constexpr @\unspec@ cend = @\unspec@;
+    constexpr @\unspec@ rbegin = @\unspec@;
+    constexpr @\unspec@ rend = @\unspec@;
+    constexpr @\unspec@ crbegin = @\unspec@;
+    constexpr @\unspec@ crend = @\unspec@;
+  }
 
   // \ref{range.primitives}, Range primitives:
-  @\newtxt{namespace \{}@
-    @\newtxt{constexpr \unspec size = \unspec;}@
-    @\newtxt{constexpr \unspec empty = \unspec;}@
-    @\newtxt{constexpr \unspec data = \unspec;}@
-    @\newtxt{constexpr \unspec cdata = \unspec;}@
-  @\newtxt{\}}@
-  @\oldtxt{Range\{R\}}\newtxt{template <Range R>}@
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>> distance(R&& r);
-  @\oldtxt{SizedRange\{R\}}\newtxt{template <SizedRange R>}@
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>> distance(R&& r);
+  namespace {
+    constexpr @\unspec@ size = @\unspec@;
+    constexpr @\unspec@ empty = @\unspec@;
+    constexpr @\unspec@ data = @\unspec@;
+    constexpr @\unspec@ cdata = @\unspec@;
+  }
+  template <Range R>
+  difference_type_t<iterator_t<R>> distance(R&& r);
+  template <SizedRange R>
+  difference_type_t<iterator_t<R>> distance(R&& r);
 \end{codeblock}
 \end{addedblock}
 \begin{codeblock}
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \begin{addedblock}
 \begin{codeblock}
 namespace std {
   // \ref{iterator.stdtraits}, iterator traits
-  template <experimental::ranges@\oldtxt{_v1}@::@\oldtxt{Weak}@Iterator I>
+  template <experimental::ranges::Iterator I>
     struct iterator_traits;
-  template <experimental::ranges@\oldtxt{_v1}@::@\oldtxt{Weak}@InputIterator I>
+  template <experimental::ranges::InputIterator I>
     struct iterator_traits;
-  template <experimental::ranges@\oldtxt{_v1}@::InputIterator I>
-      @\newtxt{requires Sentinel<I, I>()}@
+  template <experimental::ranges::InputIterator I>
+      requires Sentinel<I, I>()
     struct iterator_traits;
-
-  @\oldtxt{// \ref{counted.traits.specializations} \tcode{common_type} specializations}@
-  @\oldtxt{template<experimental::ranges_v1::WeakIterator I>}@
-    @\oldtxt{struct common_type<experimental::ranges_v1::counted_iterator<I>,}@
-                       @\oldtxt{experimental::ranges_v1::default_sentinel>;}@
-  @\oldtxt{template<experimental::ranges_v1::WeakIterator I>}@
-    @\oldtxt{struct common_type<experimental::ranges_v1::default_sentinel,}@
-                       @\oldtxt{experimental::ranges_v1::counted_iterator<I>>;}@
-
-  @\oldtxt{// \ref{unreachable.traits.specializations} \tcode{common_type} specializations}@
-  @\oldtxt{template<experimental::ranges_v1::Iterator I>}@
-    @\oldtxt{struct common_type<I, experimental::ranges_v1::unreachable>;}@
-  @\oldtxt{template<experimental::ranges_v1::Iterator I>}@
-    @\oldtxt{struct common_type<experimental::ranges_v1::unreachable, I>;}@
 }
 \end{codeblock}
 
 \pnum
 Any entities declared or defined in namespace \tcode{std} in header \tcode{<iterator>}
-that are not already defined in namespace \tcode{std::experimental::ranges\oldtxt{_v1}} in header
-\tcode{<experimental/ranges\oldtxt{_v1}/iterator>} are imported with
+that are not already defined in namespace \tcode{std::experimental::ranges} in header
+\tcode{<experimental/ranges/iterator>} are imported with
 \grammarterm{using-declaration}{s}~(\cxxref{namespace.udecl}). \ednote{There are no such
 entities, but there may be in the future.}
 \end{addedblock}
@@ -1951,12 +1585,12 @@ determine the value and
 difference types that correspond to a particular iterator type.
 Accordingly, it is required that if
 \removed{\tcode{Iterator} is the type of an iterator}
-\added{\oldtxt{\tcode{WeaklyIncrementable}}\newtxt{\tcode{WI}} is the name of a type that
+\added{\tcode{WI} is the name of a type that
 satisfies the \tcode{WeaklyIncrementable} concept~(\ref{iterators.weaklyincrementable}),
-\oldtxt{\tcode{Readable}}\newtxt{\tcode{R}} is the name of a type that
+\tcode{R} is the name of a type that
 satisfies the \tcode{Readable} concept~(\ref{iterators.readable}), and
-\oldtxt{\tcode{WeakInputIterator}}\newtxt{\tcode{II}} is the name of a type that satisfies the
-\tcode{\oldtxt{Weak}InputIterator} concept~(\ref{iterators.input}) concept}, the types
+\tcode{II} is the name of a type that satisfies the
+\tcode{InputIterator} concept~(\ref{iterators.input}) concept}, the types
 
 \begin{removedblock}
 \begin{codeblock}
@@ -1967,9 +1601,9 @@ iterator_traits<Iterator>::iterator_category
 \end{removedblock}
 \begin{addedblock}
 \begin{codeblock}
-@\oldtxt{DifferenceType<WeaklyIncrementable>}\newtxt{difference_type_t<WI>}@
-@\oldtxt{ValueType<Readable>}\newtxt{value_type_t<R>}@
-@\oldtxt{IteratorCategory<WeakInputIterator>}\newtxt{iterator_category_t<II>}@
+difference_type_t<WI>
+value_type_t<R>
+iterator_category_t<II>
 \end{codeblock}
 \end{addedblock}
 
@@ -1978,10 +1612,10 @@ In addition, the type\removed{s}
 
 \begin{addedblock}
 \begin{codeblock}
-@\tcode{\oldtxt{ReferenceType<Readable>}}\tcode{\newtxt{reference_t<R>}}@
+@\tcode{reference_t<R>}
 \end{codeblock}
 
-shall be an alias for \tcode{decltype(*declval<\oldtxt{Readable}\newtxt{R\&}>())}.
+shall be an alias for \tcode{decltype(*declval<R\&>())}.
 \end{addedblock}
 
 \begin{removedblock}
@@ -2053,7 +1687,7 @@ namespace std {
 \begin{addedblock}
 \pnum
 \indexlibrary{\idxcode{difference_type_t}}%
-\tcode{\oldtxt{DifferenceType<T>}}\tcode{\newtxt{difference_type_t<T>}} is implemented as if:
+\tcode{difference_type_t<T>} is implemented as if:
 
 \indexlibrary{\idxcode{difference_type}}%
 \begin{codeblock}
@@ -2061,38 +1695,30 @@ namespace std {
   template <class T>
   struct difference_type<T*>
     : enable_if<is_object<T>::value, ptrdiff_t> { };
-  @\oldtxt{template <>}@
-  @\oldtxt{struct difference_type<nullptr_t> \{}@
-    @\oldtxt{using type = ptrdiff_t;}@
-  @\oldtxt{\};}@
   template<class I>
     requires is_array<I>::value
   struct difference_type<I> : difference_type<decay_t<I>> { };
   template <class I>
   struct difference_type<I const> : difference_type<decay_t<I>> { };
-  @\oldtxt{template <class I>}@
-  @\oldtxt{struct difference_type<I volatile> : difference_type<decay_t<I>{}> \{ \};}@
-  @\oldtxt{template <class I>}@
-  @\oldtxt{struct difference_type<I const volatile> : difference_type<decay_t<I>{}> \{ \};}@
   template <class T>
     requires requires { typename T::difference_type; }
   struct difference_type<T> {
     using type = typename T::difference_type;
   };
   template <class T>
-    requires @\oldtxt{is_integral<T>::value}\newtxt{!requires \{ typename T::difference_type; \} \&\&}@
-      @\newtxt{requires (const T\& a, const T\& b) \{ \{ a - b \} -> Integral; \}}@
+    requires !requires { typename T::difference_type; } &&
+      requires (const T& a, const T& b) { { a - b } -> Integral; }
   struct difference_type<T>
     : make_signed< decltype(declval<T>() - declval<T>()) > {
   };
   template <class T>
-    using @\oldtxt{DifferenceType}\newtxt{difference_type_t}@ = typename difference_type<T>::type;
+    using difference_type_t = typename difference_type<T>::type;
 \end{codeblock}
 
 \ednote{REVIEW: The \tcode{difference_type} of unsigned \tcode{Integral} types
 is not large enough to cover the entire range. The Palo Alto report used
 a separate type trait for \tcode{WeaklyIncrementable}: \tcode{DistanceType}.
-\tcode{\oldtxt{DifferenceType}}\tcode{\newtxt{difference_type_t}} is only used for
+\tcode{difference_type_t} is only used for
 \tcode{RandomAccessIterator}s. Cue discussion about the pros and cons of the two approaches.}
 
 \pnum
@@ -2100,7 +1726,7 @@ Users may specialize \tcode{difference_type} on user-defined types.
 
 \pnum
 \indexlibrary{\idxcode{iterator_category_t}}%
-\tcode{\oldtxt{IteratorCategory<T>}}\tcode{\newtxt{iterator_category_t<T>}}
+\tcode{iterator_category_t<T>}
 is implemented as if:
 
 \indexlibrary{\idxcode{iterator_category}}%
@@ -2111,36 +1737,32 @@ is implemented as if:
     : enable_if<is_object<T>::value, random_access_iterator_tag> { };
   template <class T>
   struct iterator_category<T const> : iterator_category<T> { };
-  @\oldtxt{template <class T>}@
-  @\oldtxt{struct iterator_category<T volatile> : iterator_category<T> \{ \};}@
-  @\oldtxt{template <class T>}@
-  @\oldtxt{struct iterator_category<T const volatile> : iterator_category<T> \{ \};}@
   template <class T>
     requires requires { typename T::iterator_category; }
   struct iterator_category<T> {
     using type = @\seebelow@;
   };
   template <class T>
-    using @\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@ = typename iterator_category<T>::type;
+    using iterator_category_t = typename iterator_category<T>::type;
 \end{codeblock}
 
 \pnum
 Users may specialize \tcode{iterator_category} on user-defined types.
 
 \pnum
-If \oldtxt{type \tcode{T} has a nested type \tcode{iterator_category}}
-\newtxt{\tcode{T::iterator_category} is valid and denotes a type}, then the
+If 
+\tcode{T::iterator_category} is valid and denotes a type, then the
 type \tcode{iterator_category<T>::type} is computed as follows:
 \begin{itemize}
 \item If \tcode{T::iterator_category} is the same as or derives from \tcode{std::random_access_iterator_tag},
-      \tcode{iterator_category<T>::type} is \tcode{ranges\oldtxt{_v1}::random_access_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{T::iterator_category} is the same as or derives from \tcode{std::bidirectional_iterator_tag},
-      \tcode{iterator_category<T>::type} is \tcode{ranges\oldtxt{_v1}::bidirectional_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{T::iterator_category} is the same as or derives from \tcode{std::forward_iterator_tag},
-      \tcode{iterator_category<T>::type} is \tcode{ranges\oldtxt{_v1}::forward_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{T::iterator_category} is the same as or derives from \tcode{std::input_iterator_tag},
-      \tcode{iterator_category<T>::type} is \tcode{ranges\oldtxt{_v1}::input_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{T::iterator_category} is the same as or derives from \tcode{std::output_iterator_tag},
+      \tcode{iterator_category<T>::type} is \tcode{ranges::random_access_iterator_tag}.
+\item Otherwise, if \tcode{T::iterator_category} is the same as or derives from \tcode{std::bidirectional_iterator_tag},
+      \tcode{iterator_category<T>::type} is \tcode{ranges::bidirectional_iterator_tag}.
+\item Otherwise, if \tcode{T::iterator_category} is the same as or derives from \tcode{std::forward_iterator_tag},
+      \tcode{iterator_category<T>::type} is \tcode{ranges::forward_iterator_tag}.
+\item Otherwise, if \tcode{T::iterator_category} is the same as or derives from \tcode{std::input_iterator_tag},
+      \tcode{iterator_category<T>::type} is \tcode{ranges::input_iterator_tag}.
+\item Otherwise, if \tcode{T::iterator_category} is the same as or derives from \tcode{std::output_iterator_tag},
       \tcode{iterator_category<T>} has no nested \tcode{type}.
 \item Otherwise, \tcode{iterator_category<T>::type} is \tcode{T::iterator_category}
 \end{itemize}
@@ -2171,33 +1793,33 @@ an implementation may define
 
 \begin{addedblock}
 \pnum
-For the sake of backwards compatibility, this \oldtxt{standard}\newtxt{document} specifies the existence of an \tcode{iterator_traits}
+For the sake of backwards compatibility, this document specifies the existence of an \tcode{iterator_traits}
 alias that collects an iterator's associated types. It is defined as if:
 
 \indexlibrary{\idxcode{iterator_traits}}%
 \begin{codeblock}
-  template <@\oldtxt{Weak}@InputIterator I> struct @\xname{pointer_type}@ {        @\newtxt{// \expos}@
-    using type = add_pointer_t<@\oldtxt{ReferenceType}\newtxt{reference_t}@<I>>;
+  template <InputIterator I> struct @\xname{pointer_type}@ {        // \expos
+    using type = add_pointer_t<reference_t<I>>;
   };
-  template <@\oldtxt{Weak}@InputIterator I>
+  template <InputIterator I>
     requires requires(I i) { { i.operator->() } -> auto&&; }
-  struct @\xname{pointer_type}@<I> {                                    @\newtxt{// \expos}@
+  struct @\xname{pointer_type}@<I> {                                    // \expos
     using type = decltype(declval<I>().operator->());
   };
-  template <class> struct @\xname{iterator_traits}@ { };                @\newtxt{// \expos}@
-  template <@\oldtxt{Weak}@Iterator I> struct @\xname{iterator_traits}@<I> {
-    using difference_type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
+  template <class> struct @\xname{iterator_traits}@ { };                // \expos
+  template <Iterator I> struct @\xname{iterator_traits}@<I> {
+    using difference_type = difference_type_t<I>;
     using value_type = void;
     using reference = void;
     using pointer = void;
     using iterator_category = output_iterator_tag;
   };
-  template <@\oldtxt{Weak}@InputIterator I> struct @\xname{iterator_traits}@<I> {  @\newtxt{// \expos}@
-    using difference_type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-    using value_type = @\oldtxt{ValueType}\newtxt{value_type_t}@<I>;
-    using reference = @\oldtxt{ReferenceType}\newtxt{reference_t}@<I>;
+  template <InputIterator I> struct @\xname{iterator_traits}@<I> {  // \expos
+    using difference_type = difference_type_t<I>;
+    using value_type = value_type_t<I>;
+    using reference = reference_t<I>;
     using pointer = typename @\xname{pointer_type}@<I>::type;
-    using iterator_category = @\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>;
+    using iterator_category = iterator_category_t<I>;
   };
   template <class I>
     using iterator_traits = @\xname{iterator_traits}@<I>;
@@ -2206,8 +1828,7 @@ alias that collects an iterator's associated types. It is defined as if:
 \pnum
 \enternote
 \tcode{iterator_traits} is an alias template
-\oldtxt{to intentionally break code that tries to specialize it}
-\newtxt{to prevent user code from specializing it}.
+to prevent user code from specializing it.
 \exitnote
 
 \end{addedblock}
@@ -2221,11 +1842,11 @@ function, a \Cpp program can do the following:
 \begin{codeblock}
 template <@\removed{class }@BidirectionalIterator@\added{ I}@>
 void reverse(@\changed{BidirectionalIterator}{I}@ first, @\changed{BidirectionalIterator}{I}@ last) {
-  @\removed{typename iterator_traits<BidirectionalIterator>::difference_type}\oldtxt{DifferenceType<I>}\newtxt{difference_type_t<I>}@ n =
+  @\changed{typename iterator_traits<BidirectionalIterator>::difference_type}{difference_type_t<I>}@ n =
     distance(first, last);
   --n;
   while(n > 0) {
-    @\removed{typename iterator_traits<BidirectionalIterator>::value_type}\oldtxt{ValueType<I>}\newtxt{value_type_t<I>}@
+    @\changed{typename iterator_traits<BidirectionalIterator>::value_type}{value_type_t<I>}@
       tmp = *first;
     *first++ = *--last;
     *last = tmp;
@@ -2235,20 +1856,20 @@ void reverse(@\changed{BidirectionalIterator}{I}@ first, @\changed{Bidirectional
 \end{codeblock}
 \exitexample
 
-{\color{addclr}
+\begin{addedblock}
 \rSec2[iterator.stdtraits]{Standard iterator traits}
 
 \pnum
 To facilitate interoperability between new code using iterators conforming to this document
-and older code using iterators \oldtxt{conforming to}\newtxt{that conform to the iterator
-requirements specified in} ISO/IEC 14882, three specializations of \tcode{std::iterator_traits}
-are provided to map the newer iterator categories \newtxt{and associated types} to the older ones.
+and older code using iterators that conform to the iterator
+requirements specified in ISO/IEC 14882, three specializations of \tcode{std::iterator_traits}
+are provided to map the newer iterator categories and associated types to the older ones.
 
 \begin{codeblock}
 namespace std {
-  template <experimental::ranges@\oldtxt{_v1}@::@\oldtxt{Weak}@Iterator Out>
+  template <experimental::ranges::Iterator Out>
   struct iterator_traits<Out> {
-    using difference_type   = experimental::ranges@\oldtxt{_v1}@::@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<Out>;
+    using difference_type   = experimental::ranges::difference_type_t<Out>;
     using value_type        = @\seebelow@;
     using reference         = @\seebelow@;
     using pointer           = @\seebelow@;
@@ -2259,8 +1880,8 @@ namespace std {
 \pnum
 The nested type \tcode{value_type} is computed as follows:
 \begin{itemize}
-\item If \oldtxt{type \tcode{Out} has a nested type \tcode{value_type}}
-      \newtxt{\tcode{Out::value_type} is valid and denotes a type}, then
+\item If 
+      \tcode{Out::value_type} is valid and denotes a type, then
       \tcode{std::iterator_traits<Out>::value_type} is \tcode{Out::value_type}.
 \item Otherwise, \tcode{std::iterator_traits<Out>::value_type} is \tcode{void}.
 \end{itemize}
@@ -2268,8 +1889,8 @@ The nested type \tcode{value_type} is computed as follows:
 \pnum
 The nested type \tcode{reference} is computed as follows:
 \begin{itemize}
-\item If \oldtxt{type \tcode{Out} has a nested type \tcode{reference}}
-      \newtxt{\tcode{Out::reference} is valid and denotes a type}, then
+\item If 
+      \tcode{Out::reference} is valid and denotes a type, then
       \tcode{std::iterator_traits<Out>::reference} is \tcode{Out::\brk{}reference}.
 \item Otherwise, \tcode{std::iterator_traits<Out>::reference} is \tcode{void}.
 \end{itemize}
@@ -2277,21 +1898,21 @@ The nested type \tcode{reference} is computed as follows:
 \pnum
 The nested type \tcode{pointer} is computed as follows:
 \begin{itemize}
-\item If \oldtxt{type \tcode{Out} has a nested type \tcode{pointer}}
-      \newtxt{\tcode{Out::pointer} is valid and denotes a type}, then
+\item If 
+      \tcode{Out::pointer} is valid and denotes a type, then
       \tcode{std::iterator_traits<Out>::pointer} is \tcode{Out::pointer}.
 \item Otherwise, \tcode{std::iterator_traits<Out>::pointer} is \tcode{void}.
 \end{itemize}
 
 \begin{codeblock}
-  template <experimental::ranges@\oldtxt{_v1}@::@\oldtxt{Weak}@InputIterator @\oldtxt{Weak}@In>
-  struct iterator_traits<@\oldtxt{Weak}@In> { };
+  template <experimental::ranges::InputIterator In>
+  struct iterator_traits<In> { };
 
-  template <experimental::ranges@\oldtxt{_v1}@::InputIterator In>
-    @\newtxt{requires Sentinel<In, In>()}@
+  template <experimental::ranges::InputIterator In>
+    requires Sentinel<In, In>()
   struct iterator_traits<In> {
-    using difference_type   = experimental::ranges@\oldtxt{_v1}@::@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<In>;
-    using value_type        = experimental::ranges@\oldtxt{_v1}@::@\oldtxt{ValueType}\newtxt{value_type_t}@<In>;
+    using difference_type   = experimental::ranges::difference_type_t<In>;
+    using value_type        = experimental::ranges::value_type_t<In>;
     using reference         = @\seebelow@;
     using pointer           = @\seebelow@;
     using iterator_category = @\seebelow@;
@@ -2302,51 +1923,49 @@ The nested type \tcode{pointer} is computed as follows:
 \pnum
 The nested type \tcode{reference} is computed as follows:
 \begin{itemize}
-\item If \oldtxt{type \tcode{In} has a nested type \tcode{reference}}
-      \newtxt{\tcode{In::reference} is valid and denotes a type}, then
+\item If 
+      \tcode{In::reference} is valid and denotes a type, then
       \tcode{std::iterator_traits<In>::reference} is \tcode{In::reference}.
 \item Otherwise, \tcode{std::iterator_traits<In>::reference} is
-      \tcode{experimental::\-ranges\oldtxt{_v1}::\-\oldtxt{ReferenceType}\-\newtxt{reference_t}<In>}.
+      \tcode{experimental::\-ranges::\-\-reference_t<In>}.
 \end{itemize}
 
 \pnum
 The nested type \tcode{pointer} is computed as follows:
 \begin{itemize}
-\item If \oldtxt{type \tcode{In} has a nested type \tcode{pointer}}
-      \newtxt{\tcode{In::pointer} is valid and denotes a type}, then
+\item If
+      \tcode{In::pointer} is valid and denotes a type, then
       \tcode{std::iterator_traits<In>::pointer} is \tcode{In::pointer}.
 \item Otherwise, \tcode{std::iterator_traits<In>::pointer} is
-      \tcode{experimental::ranges\oldtxt{_v1}::\brk{}iterator_traits<In>::\brk{}pointer}.
+      \tcode{experimental::ranges::\brk{}iterator_traits<In>::\brk{}pointer}.
 \end{itemize}
 
 \pnum
-Let type \tcode{C} be \tcode{experimental::ranges\oldtxt{_v1}::}\tcode{\oldtxt{IteratorCategory}}\tcode{\newtxt{iterator_category_t}}\tcode{<In>}.
+Let type \tcode{C} be \tcode{experimental::ranges::}\tcode{iterator_category_t}\tcode{<In>}.
 The nested type \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category} is computed as
 follows:
 \begin{itemize}
 \item If \tcode{C} is the same as or inherits from \tcode{std::input_iterator_tag} or
       \tcode{std::output_iterator_tag}, \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category}
       is \tcode{C}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{experimental::ranges\oldtxt{_v1}::\oldtxt{ReferenceType}\newtxt{reference_t}<In>} is not a reference type,
+\item Otherwise, if \tcode{experimental::ranges::reference_t<In>} is not a reference type,
       \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category} is \tcode{std::input_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges\oldtxt{_v1}::\brk{}random_access_iterator_tag},
+\item Otherwise, if \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges::\brk{}random_access_iterator_tag},
       \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category} is \tcode{std::random_access_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges\oldtxt{_v1}::\brk{}bidirectional_iterator_tag},
+\item Otherwise, if \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges::\brk{}bidirectional_iterator_tag},
       \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category} is \tcode{std::bidirectional_iterator_tag}.
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges\oldtxt{_v1}::\brk{}forward_iterator_tag},
+\item Otherwise, if \tcode{C} is the same as or inherits from \tcode{experimental::\brk{}ranges::\brk{}forward_iterator_tag},
       \tcode{std::\brk{}iterator_traits<In>::\brk{}iterator_category} is \tcode{std::forward_iterator_tag}.
 \item Otherwise, \tcode{std::iterator_traits<In>::iterator_category} is \tcode{std::input_iterator_tag}.
 \end{itemize}
-} %% color{addclr}
 
-{\color{newclr}
 \pnum
 \enternote Some implementations may find it necessary to add additional constraints to
 these partial specializations to prevent them from being considered for types that
 conform to the iterator requirements specified in ISO/IEC 14882.\exitnote
-}
+\end{addedblock}
 
-{\color{oldoldclr}
+\begin{removedblock}
 \rSec2[iterator.basic]{Basic iterator}
 
 \pnum
@@ -2368,7 +1987,7 @@ namespace std {
   };
 }
 \end{codeblock}
-} %% color{oldoldclr}
+\end{removedblock}
 
 \rSec2[std.iterator.tags]{Standard iterator tags}
 
@@ -2389,29 +2008,27 @@ classes which \changed{are}{can be} used as compile time tags for algorithm sele
 \added{\enternote The preferred way to dispatch to more specialized algorithm implementations is
 with concept-based overloading.\exitnote}
 \changed{They}{The category tags} are:
-\tcode{\oldtxt{weak_input_iterator_tag}},
 \tcode{input_iterator_tag},
 \tcode{output_iterator_tag},
 \tcode{forward_iterator_tag},
 \tcode{bidirectional_iterator_tag}
 and
 \tcode{random_access_iterator_tag}.
-For every \oldtxt{weak }\added{input }iterator of type
-\tcode{I\oldoldtxt{terator}},
+For every \added{input }iterator of type
+\tcode{I\removed{terator}},
 \tcode{\removed{iterator_traits<Iterator>::it\-er\-a\-tor_ca\-te\-go\-ry}
-\oldtxt{It\-er\-a\-tor\-Ca\-te\-go\-ry<Iterator>}\newtxt{it\-er\-a\-tor_\-ca\-te\-go\-ry_t<I>}}
+\added{it\-er\-a\-tor_\-ca\-te\-go\-ry_t<I>}}
 shall be defined to be the most specific category tag that describes the
 iterator's behavior.
 
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   struct output_iterator_tag { };
-  @\oldtxt{struct weak_input_iterator_tag \{ \};}@
-  struct input_iterator_tag@\oldtxt{ : public weak_input_iterator_tag}@ { };
-  struct forward_iterator_tag : @\oldoldtxt{public}@ input_iterator_tag { };
-  struct bidirectional_iterator_tag : @\oldoldtxt{public}@ forward_iterator_tag { };
-  struct random_access_iterator_tag : @\oldoldtxt{public}@ bidirectional_iterator_tag { };
-}@\added{\}\}\newtxt{\}}}@
+  struct input_iterator_tag { };
+  struct forward_iterator_tag : @\removed{public}@ input_iterator_tag { };
+  struct bidirectional_iterator_tag : @\removed{public}@ forward_iterator_tag { };
+  struct random_access_iterator_tag : @\removed{public}@ bidirectional_iterator_tag { };
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \begin{addedblock}
@@ -2461,14 +2078,14 @@ template<class T> struct iterator_category<BinaryTreeIterator<T>> {
 \end{codeblock}
 \end{addedblock}
 
-\oldoldtxt{Typically, however, it would be easier to derive
+\removed{Typically, however, it would be easier to derive
 \tcode{BinaryTreeIterator<T>}
 from}
-\tcode{\oldoldtxt{iterator<bidirectional_iterator_tag, T, ptrdiff_t, T*, T\&>}}
-\oldoldtxt{.}
+\tcode{\removed{iterator<bidirectional_iterator_tag, T, ptrdiff_t, T*, T\&>}}
+\removed{.}
 \exitexample
 
-{\color{oldoldclr}
+\begin{removedblock}
 \pnum
 \enterexample
 If
@@ -2517,26 +2134,26 @@ class MyIterator :
 Then there is no need to specialize the
 \tcode{iterator_traits} template.
 \exitexample
-} %%\color{oldoldclr}
+\end{removedblock}
 
 \rSec2[iterator.operations]{Iterator operations}
 
 \pnum
 Since only \changed{random access iterators}{types that satisfy
 \tcode{RandomAccessIterator}} provide \added{the }\tcode{+} \changed{and}{operator, and
-types that satisfy \tcode{Sized\oldtxt{IteratorRange}\newtxt{Sentinel}} provide the} \tcode{-}
-operator\removed{s}, the library provides \oldoldtxt{two}\newnewtxt{four} function templates
-\tcode{advance}\newnewtxt{,}
-\oldtxt{and}
-\tcode{distance}\newnewtxt{, \tcode{next}, and \tcode{prev}}.
+types that satisfy \tcode{SizedSentinel} provide the} \tcode{-}
+operator\removed{s}, the library provides \changed{two}{four} function templates
+\tcode{advance}\added{,}
+\removed{and}
+\tcode{distance}\added{, \tcode{next}, and \tcode{prev}}.
 These
 function templates
 use
 \tcode{+}
 and
 \tcode{-}
-for random access iterators\added{ and\oldtxt{ sized iterator ranges} \newtxt{ranges that satisfy \tcode{SizedSentinel}}, respectively} (and are, therefore, constant
-time for them); for \newnewtxt{output, }\oldtxt{weak input, }input, forward and bidirectional iterators they use
+for random access iterators\added{ and ranges that satisfy \tcode{SizedSentinel}, respectively} (and are, therefore, constant
+time for them); for \added{output, }input, forward and bidirectional iterators they use
 \tcode{++}
 to provide linear time
 implementations.
@@ -2550,8 +2167,8 @@ template <class InputIterator, class Distance>
 \end{removedblock}
 \begin{addedblock}
 \begin{itemdecl}
-template <@\oldtxt{Weak}@Iterator I>
-  void advance(I& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+template <Iterator I>
+  void advance(I& i, difference_type_t<I> n);
 \end{itemdecl}
 \end{addedblock}
 
@@ -2559,14 +2176,14 @@ template <@\oldtxt{Weak}@Iterator I>
 \pnum
 \requires
 \tcode{n}
-shall be negative only for bidirectional\oldoldtxt{ and random access} iterators.
+shall be negative only for bidirectional\removed{ and random access} iterators.
 
 \pnum
 \effects
-\newnewtxt{For random access iterators, equivalent to \tcode{i += n}.
-Otherwise, i}\oldoldtxt{I}ncrements (or decrements for negative
+\added{For random access iterators, equivalent to \tcode{i += n}.
+Otherwise, i}\removed{I}ncrements (or decrements for negative
 \tcode{n})
-iterator\oldoldtxt{ reference}
+iterator\removed{ reference}
 \tcode{i}
 by
 \tcode{n}.
@@ -2581,20 +2198,18 @@ template <Iterator I, Sentinel<I> S>
 \begin{itemdescr}
 \pnum
 \requires
-\oldtxt{\tcode{bound} shall be reachable from \tcode{i}.}\newtxt{If
+If
 \tcode{Assignable<I\&, S\&\&>()} is not satisfied, \range{i}{bound}
-shall denote a range.}
+shall denote a range.
 
 \pnum
 \effects
 \begin{itemize}
-\item If \oldtxt{\tcode{I} and \tcode{S} are the same type, this function
-      is constant time}\newtxt{\tcode{Assignable<I\&, S\&\&>()} is satisfied,
-      equivalent to \tcode{i = std::move(bound)}}.
+\item If \tcode{Assignable<I\&, S\&\&>()} is satisfied,
+      equivalent to \tcode{i = std::move(bound)}.
 
-\item \oldtxt{If \tcode{SizedIteratorRange<I, S>()}}\newtxt{Otherwise, if
-      \tcode{SizedSentinel<S, I>()}} is satisfied, \oldtxt{this function
-      shall dispatch}\newtxt{equivalent} to \tcode{advance(i, bound - i)}.
+\item Otherwise, if
+      \tcode{SizedSentinel<S, I>()} is satisfied, equivalent to \tcode{advance(i, bound - i)}.
 
 \item Otherwise, increments \tcode{i} until \tcode{i == bound}.
 \end{itemize}
@@ -2602,32 +2217,29 @@ shall denote a range.}
 
 \begin{itemdecl}
 template <Iterator I, Sentinel<I> S>
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> advance(I& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, S bound);
+  difference_type_t<I> advance(I& i, difference_type_t<I> n, S bound);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \requires
-\oldtxt{\tcode{n} shall be negative only for bidirectional and random access iterators. If \tcode{n}
-is negative, \tcode{i} shall be reachable from \tcode{bound}; otherwise, \tcode{bound} shall be
-reachable from \tcode{i}.}\newtxt{If \tcode{n > 0}, \range{i}{bound} shall denote a range. If
+If \tcode{n > 0}, \range{i}{bound} shall denote a range. If
 \tcode{n == 0}, \range{i}{bound} or \range{bound}{i} shall denote a range. If \tcode{n < 0},
 \range{bound}{i} shall denote a range and \tcode{(BidirectionalIterator<I>() \&\& Same<I, S>())}
-shall be satisfied.}
+shall be satisfied.
 
 \pnum
 \effects
 \begin{itemize}
-\item If \tcode{\oldtxt{SizedIteratorRange<I, S>}\newtxt{SizedSentinel<S, I>}()} is satisfied:
+\item If \tcode{SizedSentinel<S, I>()} is satisfied:
       \begin{itemize}
-      \item If \oldtxt{\tcode{(0 <= n ? n >= $D$ : n <= $D$)} is \tcode{true}, where $D$ is \tcode{bound - i}, this
-            function dispatches}\brk{}\newtxt{$|\tcode{n}| >= |\tcode{bound - i}|$, equivalent} to \tcode{advance(i, bound)}\oldtxt{,}\newtxt{.}
+      \item If \brk{}$|\tcode{n}| >= |\tcode{bound - i}|$, equivalent to \tcode{advance(i, bound)}.
 
-      \item Otherwise, \oldtxt{this function dispatches}\newtxt{equivalent} to \tcode{advance(i, n)}.
+      \item Otherwise, equivalent to \tcode{advance(i, n)}.
       \end{itemize}
 
-\item \newtxt{Otherwise, i}\oldtxt{I}ncrements (or decrements for negative \tcode{n})
-      iterator\oldtxt{ reference} \tcode{i} either \tcode{n} times or until \tcode{i == bound},
+\item Otherwise, increments (or decrements for negative \tcode{n})
+      iterator \tcode{i} either \tcode{n} times or until \tcode{i == bound},
       whichever comes first.
 \end{itemize}
 
@@ -2649,29 +2261,29 @@ shall be satisfied.}
 \begin{addedblock}
 \begin{itemdecl}
 template <Iterator I, Sentinel<I> S>
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> distance(I first, S last);
+  difference_type_t<I> distance(I first, S last);
 \end{itemdecl}
 \end{addedblock}
 
 \begin{itemdescr}
 \pnum
-\newnewtxt{\requires
+\added{\requires
 \range{first}{last} shall denote a range, or \tcode{(Same<S, I>() \&\& SizedSentinel<S, I>())} shall be
 satisfied and \range{last}{first} shall denote a range.}
 
 \pnum
 \effects
 If \removed{\tcode{InputIterator} meets the requirements of random access iterator}
-\oldtxt{\tcode{SizedIteratorRange<I, S>()}}\brk{}\added{\tcode{\newtxt{SizedSentinel<S, I>}()} is satisfied}, returns \tcode{(last - first)}; otherwise,
+\brk{}\added{\tcode{SizedSentinel<S, I>()} is satisfied}, returns \tcode{(last - first)}; otherwise,
 returns the number of increments needed to get from
 \tcode{first}
 to
 \tcode{last}.
 
 \pnum
-\oldoldtxt{\requires
-If }\removed{\tcode{InputIterator} meets the requirements of random access iterator}\oldtxt{
-\tcode{SizedIteratorRange<I, S>()} is satisfied}\oldoldtxt{ \tcode{last} shall be reachable from
+\removed{\requires
+If \tcode{InputIterator} meets the requirements of random access iterator
+\tcode{last} shall be reachable from
 \tcode{first} or \tcode{first} shall be reachable from \tcode{last}; otherwise,
 \tcode{last}
 shall be reachable from
@@ -2688,8 +2300,8 @@ template <class ForwardIterator>
 \end{removedblock}
 \begin{addedblock}
 \begin{itemdecl}
-template <@\oldtxt{Weak}@Iterator I>
-  I next(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n = 1);
+template <Iterator I>
+  I next(I x, difference_type_t<I> n = 1);
 \end{itemdecl}
 \end{addedblock}
 
@@ -2711,7 +2323,7 @@ template <Iterator I, Sentinel<I> S>
 
 \begin{itemdecl}
 template <Iterator I, Sentinel<I> S>
-  I next(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, S bound);
+  I next(I x, difference_type_t<I> n, S bound);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2731,7 +2343,7 @@ template <class BidirectionalIterator>
 \begin{addedblock}
 \begin{itemdecl}
 template <BidirectionalIterator I>
-  I prev(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n = 1);
+  I prev(I x, difference_type_t<I> n = 1);
 \end{itemdecl}
 \end{addedblock}
 
@@ -2743,7 +2355,7 @@ template <BidirectionalIterator I>
 \begin{addedblock}
 \begin{itemdecl}
 template <BidirectionalIterator I>
-  I prev(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, I bound);
+  I prev(I x, difference_type_t<I> n, I bound);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2767,7 +2379,7 @@ is established by the identity:
 
 \indexlibrary{\idxcode{reverse_iterator}}%
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <@\changed{class Iterator}{BidirectionalIterator I}@>
   class reverse_iterator @\changed{: public}{\{}@
 \end{codeblock}\begin{removedblock}\begin{codeblock}
@@ -2785,22 +2397,20 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
     typedef typename iterator_traits<Iterator>::pointer         pointer;
 \end{codeblock}\end{removedblock}\begin{addedblock}\begin{codeblock}
     using iterator_type = I;
-    using difference_type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-    using value_type = @\oldtxt{ValueType}\newtxt{value_type_t}@<I>;
-    using iterator_category = @\oldtxt{IteratorCategory}\newtxt{iterator_category_t}@<I>;
-    using reference = @\oldtxt{ReferenceType}\newtxt{reference_t}@<I>;
+    using difference_type = difference_type_t<I>;
+    using value_type = value_type_t<I>;
+    using iterator_category = iterator_category_t<I>;
+    using reference = reference_t<I>;
     using pointer = I;
 \end{codeblock}\end{addedblock}\begin{codeblock}
     reverse_iterator();
     explicit reverse_iterator(@\changed{Iterator}{I}@ x);
-    @\oldoldtxt{template <class U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    reverse_iterator(const reverse_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
-    @\oldoldtxt{template <class U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    reverse_iterator& operator=(const reverse_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+    @\removed{template <class U>}@
+    reverse_iterator(const reverse_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
+    @\removed{template <class U>}@
+    reverse_iterator& operator=(const reverse_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 
-    @\changed{Iterator}{I}@ base() const;      @\oldoldtxt{// explicit}@
+    @\changed{Iterator}{I}@ base() const;      @\removed{// explicit}@
     reference operator*() const;
     pointer operator->() const;
 
@@ -2817,61 +2427,60 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
       @\added{requires RandomAccessIterator<I>();}@
     reverse_iterator& operator-=(difference_type n)@\removed{;}@
       @\added{requires RandomAccessIterator<I>();}@
-    @\oldoldtxt{\unspec}\newnewtxt{reference}@ operator[](difference_type n) const@\removed{;}@
+    @\changed{\unspec}{reference}@ operator[](difference_type n) const@\removed{;}@
       @\added{requires RandomAccessIterator<I>();}@
-  @\oldoldtxt{protected}\newnewtxt{private}@:
-    @\changed{Iterator}{I}@ current; @\newnewtxt{// \expos}@
+  @\changed{protected}{private}@:
+    @\changed{Iterator}{I}@ current; @\added{// \expos}@
   };
 
-  template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator==(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  @\newnewtxt{template <class I1, class I2>}@
-      @\newnewtxt{requires EqualityComparable<I1, I2>()}@
-    @\newnewtxt{bool operator!=(}@
-      @\newnewtxt{const reverse_iterator<I1>\& x,}@
-      @\newnewtxt{const reverse_iterator<I2>\& y);}@
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  @\added{template <class I1, class I2>}@
+      @\added{requires EqualityComparable<I1, I2>()}@
+    @\added{bool operator!=(}@
+      @\added{const reverse_iterator<I1>\& x,}@
+      @\added{const reverse_iterator<I2>\& y);}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  @\oldoldtxt{template <class Iterator1, class Iterator2>}@
-      @\oldtxt{requires EqualityComparable<I1, I2>()}@
-    @\oldoldtxt{bool operator!=(}@
-      @\oldoldtxt{const reverse_iterator<Iterator1>\& x,}@
-      @\oldoldtxt{const reverse_iterator<Iterator2>\& y);}@
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  @\removed{template <class Iterator1, class Iterator2>}@
+    @\removed{bool operator!=(}@
+      @\removed{const reverse_iterator<Iterator1>\& x,}@
+      @\removed{const reverse_iterator<Iterator2>\& y);}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>=(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<=(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
-      @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-    @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires SizedSentinel<I1, I2>()}@
+    @\changed{auto}{difference_type_t<I2>}@ operator-(
       const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
       const reverse_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
   template <@\changed{class Iterator}{RandomAccessIterator I}@>
     reverse_iterator<@\changed{Iterator}{I}@>
       operator+(
-    @\removed{typename reverse_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newnewtxt{difference_type_t<I>}@ n,
+    @\changed{typename reverse_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
     const reverse_iterator<@\changed{Iterator}{I}@>& x);
 
   template <@\changed{class Iterator}{BidirectionalIterator I}@>
     reverse_iterator<@\changed{Iterator}{I}@> make_reverse_iterator(@\changed{Iterator}{I}@ i);
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \begin{removedblock}
@@ -2940,9 +2549,8 @@ with \tcode{x}.
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
 
 \begin{itemdecl}
-@\oldoldtxt{template <class U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
-reverse_iterator(const reverse_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+@\removed{template <class U>}@
+reverse_iterator(const reverse_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2951,23 +2559,22 @@ reverse_iterator(const reverse_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I
 Initializes
 \tcode{current}
 with
-\tcode{\oldoldtxt{u}\newnewtxt{i}.current}.
+\tcode{\changed{u}{i}.current}.
 \end{itemdescr}
 
 \rSec4[reverse.iter.op=]{\tcode{reverse_iterator::operator=}}
 
 \indexlibrary{\idxcode{operator=}!\tcode{reverse_iterator}}%
 \begin{itemdecl}
-@\oldoldtxt{template <class U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
+@\removed{template <class U>}@
 reverse_iterator&
-  operator=(const reverse_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+  operator=(const reverse_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Assigns \tcode{\oldoldtxt{u.base()}\newnewtxt{i.current}} to \tcode{current}.
+Assigns \tcode{\changed{u.base()}{i.current}} to \tcode{current}.
 
 \pnum
 \returns
@@ -2979,7 +2586,7 @@ Assigns \tcode{\oldoldtxt{u.base()}\newnewtxt{i.current}} to \tcode{current}.
 \indexlibrary{\idxcode{base}!\idxcode{reverse_iterator}}%
 \indexlibrary{\idxcode{reverse_iterator}!\idxcode{base}}%
 \begin{itemdecl}
-@\changed{Iterator}{I}@ base() const;          @\oldoldtxt{// explicit}@
+@\changed{Iterator}{I}@ base() const;          @\removed{// explicit}@
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2997,10 +2604,10 @@ reference operator*() const;
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to \tcode{*prev(current)}}
+\effects \added{Equivalent to \tcode{*prev(current)}}
 \begin{codeblock}
-@\oldoldtxt{Iterator tmp = current;}@
-@\oldoldtxt{return *--tmp;}@
+@\removed{Iterator tmp = current;}@
+@\removed{return *--tmp;}@
 \end{codeblock}
 
 \end{itemdescr}
@@ -3014,8 +2621,8 @@ pointer operator->() const;
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to}
+\removed{\returns}
+\added{\effects Equivalent to}
 \changed{\tcode{std::addressof(operator*())}}{\tcode{prev(current)}}.
 \end{itemdescr}
 
@@ -3090,7 +2697,7 @@ return tmp;
 \indexlibrary{\idxcode{operator+}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
 reverse_iterator
-  operator+(@\oldoldtxt{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
+  operator+(@\removed{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
     @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
@@ -3105,7 +2712,7 @@ reverse_iterator
 \indexlibrary{\idxcode{operator+=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
 reverse_iterator&
-  operator+=(@\oldoldtxt{typename reverse_iterator<Iterator>::}@difference_type n)@\removed{;}@
+  operator+=(@\removed{typename reverse_iterator<Iterator>::}@difference_type n)@\removed{;}@
     @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
@@ -3124,7 +2731,7 @@ reverse_iterator&
 \indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
 reverse_iterator
-  operator-(@\oldoldtxt{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
+  operator-(@\removed{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
     @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
@@ -3139,7 +2746,7 @@ reverse_iterator
 \indexlibrary{\idxcode{operator-=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
 reverse_iterator&
-  operator-=(@\oldoldtxt{typename reverse_iterator<Iterator>::}@difference_type n)@\removed{;}@
+  operator-=(@\removed{typename reverse_iterator<Iterator>::}@difference_type n)@\removed{;}@
     @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
@@ -3157,8 +2764,8 @@ reverse_iterator&
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-@\oldoldtxt{\unspec}\newnewtxt{reference}@ operator[](
-  @\oldoldtxt{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
+@\changed{\unspec}{reference}@ operator[](
+  @\removed{typename reverse_iterator<Iterator>::}@difference_type n) const@\removed{;}@
     @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
@@ -3172,7 +2779,7 @@ reverse_iterator&
 
 \indexlibrary{\idxcode{operator==}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
     @\added{requires EqualityComparable<I1, I2>()}@
   bool operator==(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
@@ -3181,8 +2788,8 @@ template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, 
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current == y.current}.
 \end{itemdescr}
 
@@ -3190,7 +2797,7 @@ template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, 
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
     @\added{requires EqualityComparable<I1, I2>()}@
   bool operator!=(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
@@ -3199,8 +2806,8 @@ template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, 
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current != y.current}.
 \end{itemdescr}
 
@@ -3208,8 +2815,8 @@ template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, 
 
 \indexlibrary{\idxcode{operator<}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator<(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
     const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -3217,8 +2824,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current > y.current}.
 \end{itemdescr}
 
@@ -3226,8 +2833,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \indexlibrary{\idxcode{operator>}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator>(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
     const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -3235,8 +2842,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current < y.current}.
 \end{itemdescr}
 
@@ -3244,8 +2851,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator>=(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
     const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -3253,8 +2860,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current <= y.current}.
 \end{itemdescr}
 
@@ -3262,8 +2869,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator<=(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
     const reverse_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -3271,8 +2878,8 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x.current >= y.current}.
 \end{itemdescr}
 
@@ -3280,17 +2887,17 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 
 \indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{BidirectionalIterator }\added{I2}@>
-    @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-  @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires SizedSentinel<I1, I2>()}@
+  @\changed{auto}{difference_type_t<I2>}@ operator-(
     const reverse_iterator<@\changed{Iterator1}{I1}@>& x,
     const reverse_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{y.current - x.current}.
 \end{itemdescr}
 
@@ -3301,14 +2908,14 @@ template <class @\removed{Iterator1}\oldtxt{BidirectionalIterator }\added{I1}@, 
 template <@\changed{class Iterator}{RandomAccessIterator I}@>
   reverse_iterator<@\changed{Iterator}{I}@>
     operator+(
-  @\removed{typename reverse_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newtxt{difference_type_t<I>}@ n,
+  @\changed{typename reverse_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
   const reverse_iterator<@\changed{Iterator}{I}@>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{reverse_iterator<\changed{Iterator}{I}>(x.current - n)}.
 \end{itemdescr}
 
@@ -3353,7 +2960,7 @@ instead of the \techterm{regular overwrite} mode.
 \pnum
 An insert iterator is constructed from a container and possibly one of its iterators pointing to where
 insertion takes place if it is neither at the beginning nor at the end of the container.
-Insert iterators satisfy \oldoldtxt{the requirements of output iterators}\newnewtxt{\tcode{OutputIterator}}.
+Insert iterators satisfy \removed{the requirements of output iterators}\added{\tcode{OutputIterator}}.
 \tcode{operator*}
 returns the insert iterator itself.
 The assignment
@@ -3381,32 +2988,31 @@ functions making the insert iterators out of a container.
 \indexlibrary{\idxcode{back_insert_iterator}}%
 \ednote{REVIEW: Re-specify this in terms of a Container concept? Or Range? Or leave it?}
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class Container>
   class back_insert_iterator @\changed{:}{\{}@
     @\removed{public iterator<output_iterator_tag, void, void, void, void> \{}@
-  @\oldoldtxt{protected}\newtxt{private}@:
-    Container* container; @\newtxt{// \expos}@
+  @\changed{protected}{private}@:
+    Container* container; @\added{// \expos}@
 
   public:
     @\changed{typedef Container}{using}@ container_type@\added{ = Container}@;
     @\added{using difference_type = ptrdiff_t;}@
-    @\oldtxt{using iterator_category = output_iterator_tag;}@
-    @\added{\newnewtxt{constexpr} back_insert_iterator();}@
+    @\added{\added{constexpr} back_insert_iterator();}@
     explicit back_insert_iterator(Container& x);
-    back_insert_iterator@\oldoldtxt{<Container>}@&
+    back_insert_iterator@\removed{<Container>}@&
       operator=(const typename Container::value_type& value);
-    back_insert_iterator@\oldoldtxt{<Container>}@&
+    back_insert_iterator@\removed{<Container>}@&
       operator=(typename Container::value_type&& value);
 
-    back_insert_iterator@\oldoldtxt{<Container>}@& operator*();
-    back_insert_iterator@\oldoldtxt{<Container>}@& operator++();
-    back_insert_iterator@\oldoldtxt{<Container>}@ operator++(int);
+    back_insert_iterator@\removed{<Container>}@& operator*();
+    back_insert_iterator@\removed{<Container>}@& operator++();
+    back_insert_iterator@\removed{<Container>}@ operator++(int);
   };
 
   template <class Container>
     back_insert_iterator<Container> back_inserter(Container& x);
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \rSec3[back.insert.iter.ops]{\tcode{back_insert_iterator} operations}
@@ -3416,7 +3022,7 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
 \indexlibrary{\idxcode{back_insert_iterator}!\idxcode{back_insert_iterator}}%
 \begin{addedblock}
 \begin{itemdecl}
-@\newnewtxt{constexpr}@ back_insert_iterator();
+@\added{constexpr}@ back_insert_iterator();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3445,13 +3051,13 @@ with \tcode{std::addressof(x)}.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
 \begin{itemdecl}
-back_insert_iterator@\oldoldtxt{<Container>}@&
+back_insert_iterator@\removed{<Container>}@&
   operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \tcode{container->push_back(value);}
 
 \pnum
@@ -3461,13 +3067,13 @@ back_insert_iterator@\oldoldtxt{<Container>}@&
 
 \indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
 \begin{itemdecl}
-back_insert_iterator@\oldoldtxt{<Container>}@&
+back_insert_iterator@\removed{<Container>}@&
   operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \tcode{container->push_back(std::move(value));}
 
 \pnum
@@ -3479,7 +3085,7 @@ back_insert_iterator@\oldoldtxt{<Container>}@&
 
 \indexlibrary{\idxcode{operator*}!\idxcode{back_insert_iterator}}%
 \begin{itemdecl}
-back_insert_iterator@\oldoldtxt{<Container>}@& operator*();
+back_insert_iterator@\removed{<Container>}@& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3492,8 +3098,8 @@ back_insert_iterator@\oldoldtxt{<Container>}@& operator*();
 
 \indexlibrary{\idxcode{operator++}!\idxcode{back_insert_iterator}}%
 \begin{itemdecl}
-back_insert_iterator@\oldoldtxt{<Container>}@& operator++();
-back_insert_iterator@\oldoldtxt{<Container>}@ operator++(int);
+back_insert_iterator@\removed{<Container>}@& operator++();
+back_insert_iterator@\removed{<Container>}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3520,32 +3126,31 @@ template <class Container>
 
 \indexlibrary{\idxcode{front_insert_iterator}}%
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class Container>
   class front_insert_iterator @\changed{:}{\{}@
     @\removed{public iterator<output_iterator_tag, void, void, void, void> \{}@
-  @\oldoldtxt{protected}\newtxt{private}@:
-    Container* container; @\newtxt{// \expos}@
+  @\changed{protected}{private}@:
+    Container* container; @\added{// \expos}@
 
   public:
     @\changed{typedef Container}{using}@ container_type@\added{ = Container}@;
     @\added{using difference_type = ptrdiff_t;}@
-    @\oldtxt{using iterator_category = output_iterator_tag;}@
-    @\added{\newnewtxt{constexpr} front_insert_iterator();}@
+    @\added{\added{constexpr} front_insert_iterator();}@
     explicit front_insert_iterator(Container& x);
-    front_insert_iterator@\oldoldtxt{<Container>}@&
+    front_insert_iterator@\removed{<Container>}@&
       operator=(const typename Container::value_type& value);
-    front_insert_iterator@\oldoldtxt{<Container>}@&
+    front_insert_iterator@\removed{<Container>}@&
       operator=(typename Container::value_type&& value);
 
-    front_insert_iterator@\oldoldtxt{<Container>}@& operator*();
-    front_insert_iterator@\oldoldtxt{<Container>}@& operator++();
-    front_insert_iterator@\oldoldtxt{<Container>}@ operator++(int);
+    front_insert_iterator@\removed{<Container>}@& operator*();
+    front_insert_iterator@\removed{<Container>}@& operator++();
+    front_insert_iterator@\removed{<Container>}@ operator++(int);
   };
 
   template <class Container>
     front_insert_iterator<Container> front_inserter(Container& x);
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \rSec3[front.insert.iter.ops]{\tcode{front_insert_iterator} operations}
@@ -3555,7 +3160,7 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
 \indexlibrary{\idxcode{front_insert_iterator}!\idxcode{front_insert_iterator}}%
 \begin{addedblock}
 \begin{itemdecl}
-@\newnewtxt{constexpr}@ front_insert_iterator();
+@\added{constexpr}@ front_insert_iterator();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3584,13 +3189,13 @@ with \tcode{std::addressof(x)}.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
 \begin{itemdecl}
-front_insert_iterator@\oldoldtxt{<Container>}@&
+front_insert_iterator@\removed{<Container>}@&
   operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \tcode{container->push_front(value);}
 
 \pnum
@@ -3600,13 +3205,13 @@ front_insert_iterator@\oldoldtxt{<Container>}@&
 
 \indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
 \begin{itemdecl}
-front_insert_iterator@\oldoldtxt{<Container>}@&
+front_insert_iterator@\removed{<Container>}@&
   operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \tcode{container->push_front(std::move(value));}
 
 \pnum
@@ -3618,7 +3223,7 @@ front_insert_iterator@\oldoldtxt{<Container>}@&
 
 \indexlibrary{\idxcode{operator*}!\idxcode{front_insert_iterator}}%
 \begin{itemdecl}
-front_insert_iterator@\oldoldtxt{<Container>}@& operator*();
+front_insert_iterator@\removed{<Container>}@& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3631,8 +3236,8 @@ front_insert_iterator@\oldoldtxt{<Container>}@& operator*();
 
 \indexlibrary{\idxcode{operator++}!\idxcode{front_insert_iterator}}%
 \begin{itemdecl}
-front_insert_iterator@\oldoldtxt{<Container>}@& operator++();
-front_insert_iterator@\oldoldtxt{<Container>}@ operator++(int);
+front_insert_iterator@\removed{<Container>}@& operator++();
+front_insert_iterator@\removed{<Container>}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3659,33 +3264,32 @@ template <class Container>
 
 \indexlibrary{\idxcode{insert_iterator}}%
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class Container>
   class insert_iterator @\changed{:}{\{}@
     @\removed{public iterator<output_iterator_tag, void, void, void, void> \{}@
-  @\oldoldtxt{protected}\newtxt{private}@:
-    Container* container;              @\newtxt{// \expos}@
-    typename Container::iterator iter; @\newtxt{// \expos}@
+  @\changed{protected}{private}@:
+    Container* container;              @\added{// \expos}@
+    typename Container::iterator iter; @\added{// \expos}@
 
   public:
     @\changed{typedef Container}{using}@ container_type@\added{ = Container}@;
     @\added{using difference_type = ptrdiff_t;}@
-    @\oldtxt{using iterator_category = output_iterator_tag;}@
     @\added{insert_iterator();}@
     insert_iterator(Container& x, typename Container::iterator i);
-    insert_iterator@\oldoldtxt{<Container>}@&
+    insert_iterator@\removed{<Container>}@&
       operator=(const typename Container::value_type& value);
-    insert_iterator@\oldoldtxt{<Container>}@&
+    insert_iterator@\removed{<Container>}@&
       operator=(typename Container::value_type&& value);
 
-    insert_iterator@\oldoldtxt{<Container>}@& operator*();
-    insert_iterator@\oldoldtxt{<Container>}@& operator++();
-    insert_iterator@\oldoldtxt{<Container>\&}@ operator++(int);
+    insert_iterator@\removed{<Container>}@& operator*();
+    insert_iterator@\removed{<Container>}@& operator++();
+    insert_iterator@\removed{<Container>\&}@ operator++(int);
   };
 
   template <class Container>
     insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \rSec3[insert.iter.ops]{\tcode{insert_iterator} operations}
@@ -3713,11 +3317,11 @@ insert_iterator(Container& x, typename Container::iterator i);
 \end{itemdecl}
 
 \begin{itemdescr}
-{\color{newclr}
+\begin{addedblock}
 \pnum
 \requires
 \tcode{i} is an iterator into \tcode{x}.
-}%%\color{newclr}
+\end{addedblock}
 
 \pnum
 \effects
@@ -3732,13 +3336,13 @@ with \tcode{i}.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
 \begin{itemdecl}
-insert_iterator@\oldoldtxt{<Container>}@&
+insert_iterator@\removed{<Container>}@&
   operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \begin{codeblock}
 iter = container->insert(iter, value);
 ++iter;
@@ -3751,13 +3355,13 @@ iter = container->insert(iter, value);
 
 \indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
 \begin{itemdecl}
-insert_iterator@\oldoldtxt{<Container>}@&
+insert_iterator@\removed{<Container>}@&
   operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \begin{codeblock}
 iter = container->insert(iter, std::move(value));
 ++iter;
@@ -3772,7 +3376,7 @@ iter = container->insert(iter, std::move(value));
 
 \indexlibrary{\idxcode{operator*}!\idxcode{insert_iterator}}%
 \begin{itemdecl}
-insert_iterator@\oldoldtxt{<Container>}@& operator*();
+insert_iterator@\removed{<Container>}@& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3785,8 +3389,8 @@ insert_iterator@\oldoldtxt{<Container>}@& operator*();
 
 \indexlibrary{\idxcode{operator++}!\idxcode{insert_iterator}}%
 \begin{itemdecl}
-insert_iterator@\oldoldtxt{<Container>}@& operator++();
-insert_iterator@\oldoldtxt{<Container>\&}@ operator++(int);
+insert_iterator@\removed{<Container>}@& operator++();
+insert_iterator@\removed{<Container>\&}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3815,8 +3419,8 @@ template <class Container>
 Class template \tcode{move_iterator} is an iterator adaptor
 with the same behavior as the underlying iterator except that its
 indirection operator implicitly converts the value returned by the
-underlying iterator's indirection operator to an rvalue \oldoldtxt{reference}
-\newnewtxt{of the value type}.
+underlying iterator's indirection operator to an rvalue \removed{reference}
+\added{of the value type}.
 Some generic algorithms can be called with move iterators to replace
 copying with moving.
 
@@ -3834,7 +3438,6 @@ vector<string> v2(make_move_iterator(s.begin()),
 \exitexample
 
 \begin{addedblock}
-{\color{newclr}
 \pnum
 Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
 ranges together with \tcode{move_iterator}. When an iterator type \tcode{I} and
@@ -3856,16 +3459,14 @@ void move_if(I first, S last, O out, Pred pred)
 \end{codeblock}
 
 \exitexample
-} %% color{newclr}
 \end{addedblock}
 
 \rSec3[move.iterator]{Class template \tcode{move_iterator}}
 
 \indexlibrary{\idxcode{move_iterator}}%
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
-  template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@>
-    @\oldtxt{requires Same<ReferenceType<I>, ValueType<I>\&>()}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
+  template <@\changed{class Iterator}{InputIterator I}@>
   class move_iterator {
   public:
 \end{codeblock}\begin{removedblock}\begin{codeblock}
@@ -3877,25 +3478,22 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
     typedef value_type&&                                          reference;
 \end{codeblock}\end{removedblock}\begin{addedblock}\begin{codeblock}
     using iterator_type     = I;
-    using difference_type   = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-    using value_type        = @\oldtxt{ValueType}\newtxt{value_type_t}@<I>;
-    using iterator_category = @\oldtxt{IteratorCategory<I>}\newtxt{input_iterator_tag}@;
-    using reference         = @\oldtxt{ValueType<I>\&\&}\newtxt{\seebelow}@;
-    @\oldtxt{using pointer}@           @\oldtxt{= I;}@
+    using difference_type   = difference_type_t<I>;
+    using value_type        = value_type_t<I>;
+    using iterator_category = input_iterator_tag;
+    using reference         = @\seebelow@;
 \end{codeblock}\end{addedblock}\begin{codeblock}
 
     move_iterator();
     explicit move_iterator(@\changed{Iterator}{I}@ i);
-    @\oldoldtxt{template <class U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    move_iterator(const move_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
-    @\oldoldtxt{template <class U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    move_iterator& operator=(const move_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+    @\removed{template <class U>}@
+    move_iterator(const move_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
+    @\removed{template <class U>}@
+    move_iterator& operator=(const move_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 
-    @\oldoldtxt{iterator_type}\newnewtxt{I}@ base() const;
+    @\changed{iterator_type}{I}@ base() const;
     reference operator*() const;
-    @\oldoldtxt{pointer operator->() const;}@
+    @\removed{pointer operator->() const;}@
 
     move_iterator& operator++();
     move_iterator operator++(int);
@@ -3912,55 +3510,54 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \
       @\added{requires RandomAccessIterator<I>();}@
     move_iterator& operator-=(difference_type n)@\removed{;}@
       @\added{requires RandomAccessIterator<I>();}@
-    @\oldoldtxt{\unspec}\newnewtxt{reference}@ operator[](difference_type n) const@\removed{;}@
+    @\changed{\unspec}{reference}@ operator[](difference_type n) const@\removed{;}@
       @\added{requires RandomAccessIterator<I>();}@
 
   private:
     @\changed{Iterator}{I}@ current;   // \expos
   };
 
-  template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator==(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
       @\added{requires EqualityComparable<I1, I2>()}@
     bool operator!=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator<=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
-  template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-      @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires StrictTotallyOrdered<I1, I2>()}@
     bool operator>=(
       const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 
-  template <class @\removed{Iterator1}\oldtxt{WeakInputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{WeakInputIterator }\added{I2}@>
-      @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-    @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+  template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+      @\added{requires SizedSentinel<I1, I2>()}@
+    @\changed{auto}{difference_type_t<I2>}@ operator-(
       const move_iterator<@\changed{Iterator1}{I1}@>& x,
       const move_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
   template <@\changed{class Iterator}{RandomAccessIterator I}@>
     move_iterator<@\changed{Iterator}{I}@>
       operator+(
-        @\removed{typename move_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newnewtxt{difference_type_t<I>}@ n,
+        @\changed{typename move_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
         const move_iterator<@\changed{Iterator}{I}@>& x);
-  template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@>
+  template <@\changed{class Iterator}{InputIterator I}@>
     move_iterator<@\changed{Iterator}{I}@> make_move_iterator(@\changed{Iterator}{I}@ i);
-}@\added{\}\}\newtxt{\}}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \begin{addedblock}
-{\color{newclr}
 \pnum
 Let \tcode{\textit{R}} be \tcode{reference_t<I>}. If \tcode{is_reference<\textit{R}>::value}
 is \tcode{true}, the template specialization \tcode{move_iterator<I>} shall define the nested
@@ -3971,7 +3568,6 @@ as a synonym for \tcode{\textit{R}}.
 \enternote \tcode{move_iterator} does not provide an \tcode{operator->} because the class member access
 expression \tcode{\textit{i}->\textit{m}} may have different semantics than the expression
 \tcode{(*\textit{i}).\textit{m}} when the expression \tcode{*\textit{i}} is an rvalue.\exitnote
-}
 \end{addedblock}
 
 \begin{removedblock}
@@ -3997,7 +3593,7 @@ move_iterator();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{move_iterator}, value\newnewtxt{-}initializing
+\effects Constructs a \tcode{move_iterator}, value\added{-}initializing
 \tcode{current}. Iterator operations applied to the resulting
 iterator have defined behavior if and only if the corresponding operations are defined
 on a value-initialized iterator of type \tcode{\changed{Iterator}{I}}.
@@ -4018,15 +3614,14 @@ explicit move_iterator(@\changed{Iterator}{I}@ i);
 
 \indexlibrary{\idxcode{move_iterator}!constructor}%
 \begin{itemdecl}
-@\oldoldtxt{template <class U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
-move_iterator(const move_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+@\removed{template <class U>}@
+move_iterator(const move_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Constructs a \tcode{move_iterator}, initializing
-\tcode{current} with \oldoldtxt{\tcode{u.base()}}\newnewtxt{\tcode{i.current}}.
+\tcode{current} with \removed{\tcode{u.base()}}\added{\tcode{i.current}}.
 
 \begin{removedblock}
 \pnum
@@ -4040,14 +3635,13 @@ move_iterator(const move_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& 
 \indexlibrary{\idxcode{operator=}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator=}}%
 \begin{itemdecl}
-@\oldoldtxt{template <class U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
-move_iterator& operator=(const move_iterator<@\oldoldtxt{U}\newnewtxt{ConvertibleTo<I>}@>& @\oldoldtxt{u}\newnewtxt{i}@);
+@\removed{template <class U>}@
+move_iterator& operator=(const move_iterator<@\changed{U}{ConvertibleTo<I>}@>& @\changed{u}{i}@);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \oldoldtxt{\tcode{u.base()}}\newnewtxt{\tcode{i.current}} to
+\effects Assigns \removed{\tcode{u.base()}}\added{\tcode{i.current}} to
 \tcode{current}.
 
 \begin{removedblock}
@@ -4080,13 +3674,12 @@ reference operator*() const;
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
-\oldoldtxt{\tcode{std::move}}\newnewtxt{\tcode{static_cast<reference>}}\tcode{(*current)}.
+\removed{\returns}
+\added{\effects Equivalent to }
+\removed{\tcode{std::move}}\added{\tcode{static_cast<reference>}}\tcode{(*current)}.
 \end{itemdescr}
 
 \begin{removedblock}
-{\color{oldclr}
 \rSec4[move.iter.op.ref]{\tcode{move_iterator::operator->}}
 
 \indexlibrary{\idxcode{operator->}!\idxcode{move_iterator}}%
@@ -4099,7 +3692,6 @@ pointer operator->() const;
 \pnum
 \returns \tcode{current}.
 \end{itemdescr}
-} %% color{oldclr}
 \end{removedblock}
 
 \rSec4[move.iter.op.incr]{\tcode{move_iterator::operator++}}
@@ -4112,7 +3704,7 @@ move_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to} \tcode{++current}.
+\effects Equivalent to \tcode{++current}.
 
 \pnum
 \returns \tcode{*this}.
@@ -4126,7 +3718,7 @@ move_iterator operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 move_iterator tmp = *this;
 ++current;
@@ -4145,7 +3737,7 @@ move_iterator& operator--()@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to} \tcode{\dcr{}current}.
+\effects Equivalent to \tcode{\dcr{}current}.
 
 \pnum
 \returns \tcode{*this}.
@@ -4160,7 +3752,7 @@ move_iterator operator--(int)@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 move_iterator tmp = *this;
 --current;
@@ -4179,8 +3771,8 @@ move_iterator operator+(difference_type n) const@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{move_iterator(current + n)}.
 \end{itemdescr}
 
@@ -4195,7 +3787,7 @@ move_iterator& operator+=(difference_type n)@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to} \tcode{current += n}.
+\effects Equivalent to \tcode{current += n}.
 
 \pnum
 \returns \tcode{*this}.
@@ -4212,8 +3804,8 @@ move_iterator operator-(difference_type n) const@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{move_iterator(current - n)}.
 \end{itemdescr}
 
@@ -4228,7 +3820,7 @@ move_iterator& operator-=(difference_type n)@\removed{;}@
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to} \tcode{current -= n}.
+\effects Equivalent to \tcode{current -= n}.
 
 \pnum
 \returns \tcode{*this}.
@@ -4239,15 +3831,15 @@ move_iterator& operator-=(difference_type n)@\removed{;}@
 \indexlibrary{\idxcode{operator[]}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator[]}}%
 \begin{itemdecl}
-@\oldoldtxt{\unspec}\newnewtxt{reference}@ operator[](difference_type n) const@\removed{;}@
+@\changed{\unspec}{reference}@ operator[](difference_type n) const@\removed{;}@
   @\added{requires RandomAccessIterator<I>();}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
-\oldoldtxt{\tcode{std::move}}\newnewtxt{\tcode{static_cast<reference>}}\tcode{(current[n])}.
+\removed{\returns}
+\added{\effects Equivalent to }
+\removed{\tcode{std::move}}\added{\tcode{static_cast<reference>}}\tcode{(current[n])}.
 \end{itemdescr}
 
 \rSec4[move.iter.op.comp]{\tcode{move_iterator} comparisons}
@@ -4255,7 +3847,7 @@ move_iterator& operator-=(difference_type n)@\removed{;}@
 \indexlibrary{\idxcode{operator==}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator==}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
     @\added{requires EqualityComparable<I1, I2>()}@
   bool operator==(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -4263,15 +3855,15 @@ template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
-\tcode{x.\oldoldtxt{base()}\newnewtxt{current} == y.\oldoldtxt{base()}\newnewtxt{current}}.
+\removed{\returns}
+\added{\effects Equivalent to }
+\tcode{x.\changed{base()}{current} == y.\changed{base()}{current}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{InputIterator }\added{I2}@>
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
     @\added{requires EqualityComparable<I1, I2>()}@
   bool operator!=(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
@@ -4279,72 +3871,72 @@ template <class @\removed{Iterator1}\oldtxt{InputIterator }\added{I1}@, class @\
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{!(x == y)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator<}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator<(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
-\tcode{x.\oldoldtxt{base()}\newnewtxt{current} < y.\oldoldtxt{base()}\newnewtxt{current}}.
+\removed{\returns}
+\added{\effects Equivalent to }
+\tcode{x.\changed{base()}{current} < y.\changed{base()}{current}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator<=}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator<=(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator>}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator>(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator>=}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{RandomAccessIterator }\added{I2}@>
-    @\added{requires \newtxt{Strict}TotallyOrdered<I1, I2>()}@
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires StrictTotallyOrdered<I1, I2>()}@
   bool operator>=(
     const move_iterator<@\changed{Iterator1}{I1}@>& x, const move_iterator<@\changed{Iterator2}{I2}@>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{!(x < y)}.
 \end{itemdescr}
 
@@ -4353,18 +3945,18 @@ template <class @\removed{Iterator1}\oldtxt{RandomAccessIterator }\added{I1}@, c
 \indexlibrary{\idxcode{operator-}!\idxcode{move_iterator}}%
 \indexlibrary{\idxcode{move_iterator}!\idxcode{operator-}}%
 \begin{itemdecl}
-template <class @\removed{Iterator1}\oldtxt{WeakInputIterator }\added{I1}@, class @\removed{Iterator2}\oldtxt{WeakInputIterator }\added{I2}@>
-    @\added{requires \oldtxt{SizedIteratorRange<I2, I1>}\newtxt{SizedSentinel<I1, I2>}()}@
-  @\removed{auto}\oldtxt{DifferenceType<I2>}\newnewtxt{difference_type_t<I2>}@ operator-(
+template <class @\changed{Iterator1}{I1}@, class @\changed{Iterator2}{I2}@>
+    @\added{requires SizedSentinel<I1, I2>()}@
+  @\changed{auto}{difference_type_t<I2>}@ operator-(
     const move_iterator<@\changed{Iterator1}{I1}@>& x,
     const move_iterator<@\changed{Iterator2}{I2}@>& y)@\removed{ ->decltype(y.base() - x.base())}@;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
-\tcode{x.\oldoldtxt{base()}\newnewtxt{current} - y.\oldoldtxt{base()}\newnewtxt{current}}.
+\removed{\returns}
+\added{\effects Equivalent to }
+\tcode{x.\changed{base()}{current} - y.\changed{base()}{current}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator+}!\idxcode{move_iterator}}%
@@ -4373,20 +3965,20 @@ template <class @\removed{Iterator1}\oldtxt{WeakInputIterator }\added{I1}@, clas
 template <@\changed{class Iterator}{RandomAccessIterator I}@>
   move_iterator<@\changed{Iterator}{I}@>
     operator+(
-      @\removed{typename move_iterator<Iterator>::difference_type}\oldtxt{DifferenceType<I>}\newnewtxt{difference_type_t<I>}@ n,
+      @\changed{typename move_iterator<Iterator>::difference_type}{difference_type_t<I>}@ n,
       const move_iterator<@\changed{Iterator}{I}@>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to }
+\removed{\returns}
+\added{\effects Equivalent to }
 \tcode{x + n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_move_iterator}}%
 \begin{itemdecl}
-template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@>
+template <@\changed{class Iterator}{InputIterator I}@>
   move_iterator<@\changed{Iterator}{I}@> make_move_iterator(@\changed{Iterator}{I}@ i);
 \end{itemdecl}
 
@@ -4396,7 +3988,6 @@ template <@\removed{class Iterator}\oldtxt{Weak}\added{InputIterator I}@>
 \end{itemdescr}
 
 \begin{addedblock}
-{\color{newclr}
 \rSec3[move.sentinel]{Class template \tcode{move_sentinel}}
 
 \indexlibrary{\idxcode{move_sentinel}}%
@@ -4562,7 +4153,6 @@ template <Semiregular S>
 \pnum
 \returns \tcode{move_sentinel<S>(s)}.
 \end{itemdescr}
-} %% color{newclr}
 
 \rSec2[iterators.common]{Common iterators}
 
@@ -4575,10 +4165,7 @@ equality comparison operators appropriately.
 
 \pnum
 \enternote The \tcode{common_iterator} type is useful for interfacing with legacy
-code that expects the begin and end of a range to have the same type\oldtxt{, and for
-use in \tcode{common_type} specializations that are required to make
-iterator/sentinel pairs satisfy the \tcode{EqualityComparable}
-concept}.\exitnote
+code that expects the begin and end of a range to have the same type.\exitnote
 
 \pnum
 \enterexample
@@ -4601,53 +4188,24 @@ fun(CI(make_counted_iterator(s.begin(), 10)),
 
 \indexlibrary{\idxcode{common_iterator}}%
 \begin{codeblock}
-namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\{ inline namespace v1}@ {
-  @\oldtxt{// \expos}@
-  @\oldtxt{template<class A, class B>}@
-  @\oldtxt{concept bool \xname{WeaklyEqualityComparable} =}@
-    @\oldtxt{EqualityComparable<A>() \&\& EqualityComparable<B>() \&\&}@
-    @\oldtxt{requires(const A a, const B b) \{}@
-      @\oldtxt{\{a==b\} -> Boolean;}@
-      @\oldtxt{\{a!=b\} -> Boolean;}@
-      @\oldtxt{\{b==a\} -> Boolean;}@
-      @\oldtxt{\{b!=a\} -> Boolean;}@
-    @\oldtxt{\};}@
-  @\oldtxt{template<class S, class I>}@
-  @\oldtxt{concept bool \xname{WeakSentinel} =        // \expos}@
-    @\oldtxt{Iterator<I>() \&\& Regular<S>() \&\&}@
-    @\oldtxt{\xname{WeaklyEqualityComparable}<I, S>;}@
-  @\oldtxt{template <InputIterator I>}@
-    @\oldtxt{constexpr bool \xname{fwd_iter} = false; // \expos}@
-  @\oldtxt{template <ForwardIterator I>}@
-    @\oldtxt{constexpr bool \xname{fwd_iter}<I> = true;}@
-
-  template <@\oldtxt{Input}@Iterator I, @\oldtxt{\xname{Weak}}@Sentinel<I> S>
+namespace std { namespace experimental { namespace ranges { inline namespace v1 {
+  template <Iterator I, Sentinel<I> S>
     requires !Same<I, S>()
   class common_iterator {
   public:
-    using difference_type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-    @\oldtxt{using value_type = ValueType<I>;}@
-    @\oldtxt{using iterator_category =}@
-      @\oldtxt{conditional_t<\xname{fwd_iter}<I>,}@
-                    @\oldtxt{std::forward_iterator_tag,}@
-                    @\oldtxt{std::input_iterator_tag>;}@
-    @\oldtxt{using reference = ReferenceType<I>;}@
+    using difference_type = difference_type_t<I>;
 
     common_iterator();
     common_iterator(I i);
     common_iterator(S s);
-    @\oldtxt{template <class U, class V>}@
-      @\oldtxt{requires ConvertibleTo<U, I>() \&\& ConvertibleTo<V, S>()}@
-    common_iterator(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@, @\oldtxt{V}\newtxt{ConvertibleTo<S>}@>& u);
-    @\oldtxt{template <class U, class V>}@
-      @\oldtxt{requires ConvertibleTo<U, I>() \&\& ConvertibleTo<V, S>()}@
-    common_iterator& operator=(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@, @\oldtxt{V}\newtxt{ConvertibleTo<S>}@>& u);
+    common_iterator(const common_iterator<ConvertibleTo<I>, ConvertibleTo<S>>& u);
+    common_iterator& operator=(const common_iterator<ConvertibleTo<I>, ConvertibleTo<S>>& u);
 
     ~common_iterator();
 
-    @\newtxt{\seebelow}@ @{\newtxt{operator*();}@
-    @\oldtxt{reference}\newtxt{\seebelow}@ operator*() const;
-    @\newtxt{\seebelow}@ @\newtxt{operator->() const requires Readable<I>();}@
+    @\seebelow@ {operator*();
+    @\seebelow@ operator*() const;
+    @\seebelow@ operator->() const requires Readable<I>();
 
     common_iterator& operator++();
     common_iterator operator++(int);
@@ -4658,61 +4216,37 @@ namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\
     S sent;           // \expos
   };
 
-  @\newtxt{template <Readable I, class S>}@
-  @\newtxt{struct value_type<common_iterator<I, S>{>} \{}@
-    @\newtxt{using type = value_type_t<I>;}@
-  @\newtxt{\};}@
+  template <Readable I, class S>
+  struct value_type<common_iterator<I, S>> {
+    using type = value_type_t<I>;
+  };
 
-  @\newtxt{template <InputIterator I, class S>}@
-  @\newtxt{struct iterator_category<common_iterator<I, S>{>} \{}@
-    @\newtxt{using type = input_iterator_tag;}@
-  @\newtxt{\};}@
+  template <InputIterator I, class S>
+  struct iterator_category<common_iterator<I, S>> {
+    using type = input_iterator_tag;
+  };
 
-  @\newtxt{template <ForwardIterator I, class S>}@
-  @\newtxt{struct iterator_category<common_iterator<I, S>{>} \{}@
-    @\newtxt{using type = forward_iterator_tag;}@
-  @\newtxt{\};}@
+  template <ForwardIterator I, class S>
+  struct iterator_category<common_iterator<I, S>> {
+    using type = forward_iterator_tag;
+  };
 
-  @\newtxt{template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>}@
-  @\newtxt{bool operator==(}@
-    @\newtxt{const common_iterator<I1, S1>\& x, const common_iterator<I2, S2>\& y);}@
-  template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-    requires EqualityComparable<I1, I2>()@\oldtxt{ \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-      @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
   bool operator==(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
-  template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-    @\oldtxt{requires EqualityComparable<I1, I2>() \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-      @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
+    requires EqualityComparable<I1, I2>()
+  bool operator==(
+    const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
+  template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
   bool operator!=(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 
-  @\oldtxt{template <class I1, class S1, class I2, class S2>}@
-    @\oldtxt{requires SizedIteratorRange<I1, I1>() \&\& SizedIteratorRange<I2, I2>() \&\&}@
-      @\oldtxt{requires (const I1 i1, const S1 s1, const I2 i2, const S2 s2) \{}@
-        @\oldtxt{\{i1-i2\}->DifferenceType<I2>; \{i2-i1\}->DifferenceType<I2>;}@
-        @\oldtxt{\{i1-s2\}->DifferenceType<I2>; \{s2-i1\}->DifferenceType<I2>;}@
-        @\oldtxt{\{i2-s1\}->DifferenceType<I2>; \{s1-i2\}->DifferenceType<I2>;}@
-      @\oldtxt{\}}@
-  @\newtxt{template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>}@
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+  template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>
+  difference_type_t<I2> operator-(
     const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
-}}}@\newtxt{\}}@
+}}}}
 \end{codeblock}
-
-\oldtxt{
-\pnum
-\enternote The use of the expository \tcode{\xname{WeaklyEqualityComparable}} and
-\tcode{\xname{WeakSentinel}} concepts is to avoid the self-referential requirements that
-would happen if parameters \tcode{I} and \tcode{S} use \tcode{common_iterator<I, S>}
-as their common type.\exitnote
-}
-
-\oldtxt{
-\pnum
-\enternote The ad hoc constraints on \tcode{common_iterator}'s \tcode{operator-}
-exist for the same reason.\exitnote
-}
 
 \pnum
 \enternote It is unspecified whether \tcode{common_iterator}'s members
@@ -4734,9 +4268,8 @@ and \tcode{iter}. Iterator operations applied to the resulting iterator have def
 behavior if and only if the corresponding operations are defined on a
 value-initialized iterator of type \tcode{I}.
 
-\newtxt{
 \pnum
-\remarks} It is unspecified whether any initialization is performed for
+\remarks It is unspecified whether any initialization is performed for
 \tcode{sent}.
 \end{itemdescr}
 
@@ -4751,9 +4284,8 @@ common_iterator(I i);
 \tcode{is_sentinel} with \tcode{false} and \tcode{iter} with \tcode{i}.
 \end{itemdescr}
 
-\newtxt{
 \pnum
-\remarks} It is unspecified whether any initialization is performed for
+\remarks It is unspecified whether any initialization is performed for
 \tcode{sent}.
 
 \indexlibrary{\idxcode{common_iterator}!constructor}%
@@ -4767,16 +4299,13 @@ common_iterator(S s);
 \tcode{is_sentinel} with \tcode{true} and \tcode{sent} with \tcode{s}.
 \end{itemdescr}
 
-\newtxt{
 \pnum
-\remarks} It is unspecified whether any initialization is performed for
+\remarks It is unspecified whether any initialization is performed for
 \tcode{iter}.
 
 \indexlibrary{\idxcode{common_iterator}!constructor}%
 \begin{itemdecl}
-@\oldtxt{template <class U, class V>}@
-  @\oldtxt{requires ConvertibleTo<U, I>() \&\& ConvertibleTo<V, S>()}@
-common_iterator(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@, @\oldtxt{V}\newtxt{ConvertibleTo<S>}@>& u);
+common_iterator(const common_iterator<ConvertibleTo<I>, ConvertibleTo<S>>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4788,12 +4317,11 @@ common_iterator(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@, @\o
 \item If \tcode{u.is_sentinel} is \tcode{false}, \tcode{iter} is initialized with \tcode{u.iter}.
 \end{itemize}
 
-\newtxt{
-\remarks}
+\remarks
 \begin{itemize}
-\item \newtxt{If \tcode{u.is_sentinel} is \tcode{true},} it is unspecified whether any initialization
+\item If \tcode{u.is_sentinel} is \tcode{true}, it is unspecified whether any initialization
 is performed for \tcode{iter}.
-\item \newtxt{If \tcode{u.is_sentinel} is \tcode{false},} it is unspecified whether any initialization
+\item If \tcode{u.is_sentinel} is \tcode{false}, it is unspecified whether any initialization
 is performed for \tcode{sent}.
 \end{itemize}
 \end{itemdescr}
@@ -4803,9 +4331,7 @@ is performed for \tcode{sent}.
 \indexlibrary{\idxcode{operator=}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator=}}%
 \begin{itemdecl}
-@\oldtxt{template <class U, class V>}@
-  @\oldtxt{requires ConvertibleTo<U, I>() \&\& ConvertibleTo<V, S>()}@
-common_iterator& operator=(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@, @\oldtxt{V}\newtxt{ConvertibleTo<S>}@>& u);
+common_iterator& operator=(const common_iterator<ConvertibleTo<I>, ConvertibleTo<S>>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4816,12 +4342,11 @@ common_iterator& operator=(const common_iterator<@\oldtxt{U}\newtxt{ConvertibleT
 \item If \tcode{u.is_sentinel} is \tcode{false}, assigns \tcode{u.iter} to \tcode{iter}.
 \end{itemize}
 
-\newtxt{
-\remarks}
+\remarks
 \begin{itemize}
-\item \newtxt{If \tcode{u.is_sentinel} is \tcode{true},} it is unspecified whether any operation
+\item If \tcode{u.is_sentinel} is \tcode{true}, it is unspecified whether any operation
 is performed on \tcode{iter}.
-\item \newtxt{If \tcode{u.is_sentinel} is \tcode{false},} it is unspecified whether any operation
+\item If \tcode{u.is_sentinel} is \tcode{false}, it is unspecified whether any operation
 is performed on \tcode{sent}.
 \end{itemize}
 
@@ -4837,7 +4362,7 @@ is performed on \tcode{sent}.
 \begin{itemdescr}
 \pnum
 \effects
-\oldtxt{Runs the destructor(s) for}\newtxt{Destroys} any members that are currently initialized.
+Destroys any members that are currently initialized.
 \end{itemdescr}
 
 \rSec4[common.iter.op.star]{\tcode{common_iterator::operator*}}
@@ -4845,8 +4370,8 @@ is performed on \tcode{sent}.
 \indexlibrary{\idxcode{operator*}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator*}}%
 \begin{itemdecl}
-@\newtxt{decltype(auto) operator*();}@
-@\oldtxt{reference}\newtxt{decltype(auto)}@ operator*() const;
+decltype(auto) operator*();
+decltype(auto) operator*() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4854,15 +4379,13 @@ is performed on \tcode{sent}.
 \requires \tcode{!is_sentinel}
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to} \tcode{*iter}.
+\effects Equivalent to \tcode{*iter}.
 \end{itemdescr}
 
-{\color{newclr}
 \indexlibrary{\idxcode{operator->}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator->}}%
 \begin{itemdecl}
-@\newtxt{\seebelow}@ @\newtxt{operator->() const requires Readable<I>();}@
+@\seebelow@ operator->() const requires Readable<I>();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4893,7 +4416,7 @@ is performed on \tcode{sent}.
       that is initialized with \tcode{*iter}.
 \end{itemize}
 \end{itemdescr}
-}
+
 
 \rSec4[common.iter.op.incr]{\tcode{common_iterator::operator++}}
 
@@ -4925,7 +4448,7 @@ common_iterator operator++(int);
 \requires \tcode{!is_sentinel}
 
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 common_iterator tmp = *this;
 ++iter;
@@ -4935,7 +4458,6 @@ return tmp;
 
 \rSec4[common.iter.op.comp]{\tcode{common_iterator} comparisons}
 
-{\color{newclr}
 \indexlibrary{\idxcode{operator==}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator==}}%
 \begin{itemdecl}
@@ -4953,22 +4475,19 @@ x.is_sentinel ?
     (!y.is_sentinel || x.iter == y.sent)
 \end{codeblock}
 \end{itemdescr}
-} %% color{newclr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator==}}%
 \begin{itemdecl}
-template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-  requires EqualityComparable<I1, I2>()@\oldtxt{ \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-    @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
+  requires EqualityComparable<I1, I2>()
 bool operator==(
   const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \begin{codeblock}
 x.is_sentinel ?
     (y.is_sentinel || y.iter == x.sent) :
@@ -4981,39 +4500,28 @@ x.is_sentinel ?
 \indexlibrary{\idxcode{operator"!=}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class I1, class @\oldtxt{S1}\newtxt{I2}@, @\oldtxt{class I2}\newtxt{Sentinel<I2> S1}@, @\oldtxt{class}\newtxt{Sentinel<I1>}@ S2>
-  @\oldtxt{requires EqualityComparable<I1, I2>() \&\& \xname{WeaklyEqualityComparable}<I1, S2> \&\&}@
-    @\oldtxt{\xname{WeaklyEqualityComparable}<I2, S1>}@
+template <class I1, class I2, Sentinel<I2> S1, Sentinel<I1> S2>
 bool operator!=(
   const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{!(x == y)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{common_iterator}}%
 \indexlibrary{\idxcode{common_iterator}!\idxcode{operator-}}%
 \begin{itemdecl}
-@\oldtxt{template <class I1, class S1, class I2, class S2>}@
-  @\oldtxt{requires SizedIteratorRange<I1, I1>() \&\& SizedIteratorRange<I2, I2>() \&\&}@
-    @\oldtxt{requires (const I1 i1, const S1 s1, const I2 i2, const S2 s2) \{}@
-      @\oldtxt{\{i1-i2\}->DifferenceType<I2>; \{i2-i1\}->DifferenceType<I2>;}@
-      @\oldtxt{\{i1-s2\}->DifferenceType<I2>; \{s2-i1\}->DifferenceType<I2>;}@
-      @\oldtxt{\{i2-s1\}->DifferenceType<I2>; \{s1-i2\}->DifferenceType<I2>;}@
-    @\oldtxt{\}}@
-@\newtxt{template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>}@
-@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1, SizedSentinel<I1> S2>
+difference_type_t<I2> operator-(
   const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \begin{codeblock}
 x.is_sentinel ?
     (y.is_sentinel ? 0 : x.sent - y.iter) :
@@ -5029,100 +4537,15 @@ x.is_sentinel ?
 
 \indexlibrary{\idxcode{default_sentinel}}%
 \begin{itemdecl}
-namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\{ inline namespace v1}@ {
+namespace std { namespace experimental { namespace ranges { inline namespace v1 {
   class default_sentinel { };
-}}}@\newtxt{\}}@
+}}}}
 \end{itemdecl}
 
 \pnum
 Class \tcode{default_sentinel} is an empty type used to denote the end of a
 range. It is intended to be used together with iterator types that know the bound
 of their range (e.g., \tcode{counted_iterator}~(\ref{counted.iterator})).
-
-{\color{oldclr}
-\rSec3[default.sent.ops]{\tcode{default_sentinel} operations}
-
-\rSec4[default.sent.op.comp]{\tcode{default_sentinel} comparisons}
-
-\indexlibrary{\idxcode{operator==}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator==}}%
-\begin{itemdecl}
-constexpr bool operator==(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{true}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator"!=}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator"!=}}%
-\begin{itemdecl}
-constexpr bool operator!=(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{false}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator<}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator<}}%
-\begin{itemdecl}
-constexpr bool operator<(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{false}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator<=}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator<=}}%
-\begin{itemdecl}
-constexpr bool operator<=(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{true}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator>}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator>}}%
-\begin{itemdecl}
-constexpr bool operator>(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{false}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator>=}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator>=}}%
-\begin{itemdecl}
-constexpr bool operator>=(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{true}
-\end{itemdescr}
-
-\rSec4[default.sent.nonmember]{\tcode{default_sentinel} non-member functions}
-
-\indexlibrary{\idxcode{operator-}!\idxcode{default_sentinel}}%
-\indexlibrary{\idxcode{default_sentinel}!\idxcode{operator-}}%
-\begin{itemdecl}
-constexpr ptrdiff_t operator-(default_sentinel x, default_sentinel y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{0}
-\end{itemdescr}
-} %% color{oldclr}
 
 \rSec2[iterators.counted]{Counted iterators}
 
@@ -5139,7 +4562,7 @@ position without needing to know the end position \textit{a priori}.
 
 \begin{codeblock}
 list<string> s;
-// populate the list \tcode{s}\newtxt{ with at least 10 strings}
+// populate the list \tcode{s} with at least 10 strings
 vector<string> v(make_counted_iterator(s.begin(), 10),
                  default_sentinel()); // copies 10 strings into \tcode{v}
 \end{codeblock}
@@ -5155,27 +4578,22 @@ and \tcode{next(i2.base(), i2.count())} refer to the same (possibly past-the-end
 
 \indexlibrary{\idxcode{counted_iterator}}%
 \begin{codeblock}
-namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\{ inline namespace v1}@ {
-  template <@\oldtxt{Weak}@Iterator I>
+namespace std { namespace experimental { namespace ranges { inline namespace v1 {
+  template <Iterator I>
   class counted_iterator {
   public:
     using iterator_type = I;
-    using difference_type = @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I>;
-    @\oldtxt{using reference = ReferenceType<I>;}@
+    using difference_type = difference_type_t<I>;
 
     counted_iterator();
-    counted_iterator(I x, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
-    @\oldtxt{template <WeakIterator U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    counted_iterator(const counted_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@>& @\oldtxt{u}\newtxt{i}@);
-    @\oldtxt{template <WeakIterator U>}@
-      @\oldtxt{requires ConvertibleTo<U, I>()}@
-    counted_iterator& operator=(const counted_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@>& @\oldtxt{u}\newtxt{i}@);
+    counted_iterator(I x, difference_type_t<I> n);
+    counted_iterator(const counted_iterator<ConvertibleTo<I>>& i);
+    counted_iterator& operator=(const counted_iterator<ConvertibleTo<I>>& i);
 
     I base() const;
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> count() const;
-    @\newtxt{\seebelow}@ @\newtxt{operator*();}@
-    @\oldtxt{reference}\newtxt{\seebelow}@ operator*() const;
+    difference_type_t<I> count() const;
+    @\seebelow@ operator*();
+    @\seebelow@ operator*() const;
 
     counted_iterator& operator++();
     counted_iterator operator++(int);
@@ -5192,108 +4610,78 @@ namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\
       requires RandomAccessIterator<I>();
     counted_iterator& operator-=(difference_type n)
       requires RandomAccessIterator<I>();
-    @\oldtxt{\unspec}\newtxt{\seebelow}@ operator[](difference_type n) const
+    @\seebelow@ operator[](difference_type n) const
       requires RandomAccessIterator<I>();
-  @\oldtxt{protected}\newtxt{private}@:
-    I current; @\newtxt{// \expos}@
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> cnt; @\newtxt{// \expos}@
+  private:
+    I current; // \expos
+    difference_type_t<I> cnt; // \expos
   };
 
-  template <@\oldtxt{WeakInputIterator}\newtxt{Readable}@ I>
-  struct value_type<counted_iterator<I>>@\oldtxt{ : value_type<I>}@ {@\oldtxt{ \};}@
-    @\newtxt{using type = value_type_t<I>;}@
-  @\newtxt{\};}@
+  template <Readable I>
+  struct value_type<counted_iterator<I>> {
+    using type = value_type_t<I>;
+  };
 
-  template <@\oldtxt{Weak}@InputIterator I>
+  template <InputIterator I>
   struct iterator_category<counted_iterator<I>> {
-    using type = @\oldtxt{input_iterator_tag}\newtxt{iterator_category_t<I>}@;
+    using type = iterator_category_t<I>;
   };
-  @\oldtxt{template <ForwardIterator I>}@
-  @\oldtxt{struct iterator_category<counted_iterator<I>{>} : iterator_category<I> \{ \};}@
 
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator==(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
     bool operator==(
-      const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel@\oldtxt{ y}@);
-  @\oldtxt{template <WeakIterator I>}@
+      const counted_iterator<auto>& x, default_sentinel);
     bool operator==(
-      default_sentinel@\oldtxt{ x}@, const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& @\oldtxt{y}\newtxt{x}@);
+      default_sentinel, const counted_iterator<auto>& x);
 
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator!=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
     bool operator!=(
-      const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel y);
-  @\oldtxt{template <WeakIterator I>}@
+      const counted_iterator<auto>& x, default_sentinel y);
     bool operator!=(
-      default_sentinel x, const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& y);
+      default_sentinel x, const counted_iterator<auto>& y);
 
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator<(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator<=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<=(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator<=(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator>(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
     bool operator>=(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>=(}@
-      @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-  @\oldtxt{template <WeakIterator I>}@
-    @\oldtxt{bool operator>=(}@
-      @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+    difference_type_t<I2> operator-(
       const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+  template <class I>
+    difference_type_t<I> operator-(
       const counted_iterator<I>& x, default_sentinel y);
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-    @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+  template <class I>
+    difference_type_t<I> operator-(
       default_sentinel x, const counted_iterator<I>& y);
 
   template <RandomAccessIterator I>
     counted_iterator<I>
-      operator+(@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, const counted_iterator<I>& x);
+      operator+(difference_type_t<I> n, const counted_iterator<I>& x);
 
-  template <@\oldtxt{Weak}@Iterator I>
-    counted_iterator<I> make_counted_iterator(I i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+  template <Iterator I>
+    counted_iterator<I> make_counted_iterator(I i, difference_type_t<I> n);
 
-  template <@\oldtxt{Weak}@Iterator I>
-    void advance(counted_iterator<I>& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
-}}}@\newtxt{\}}@
+  template <Iterator I>
+    void advance(counted_iterator<I>& i, difference_type_t<I> n);
+}}}}
 \end{codeblock}
 
 \rSec3[counted.iter.ops]{\tcode{counted_iterator} operations}
@@ -5307,7 +4695,7 @@ counted_iterator();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{counted_iterator}, value\newtxt{-}initializing
+\effects Constructs a \tcode{counted_iterator}, value-initializing
 \tcode{current} and \tcode{cnt}. Iterator operations applied to the
 resulting iterator have defined behavior if and only if the corresponding operations
 are defined on a value-initialized iterator of type \tcode{I}.
@@ -5315,7 +4703,7 @@ are defined on a value-initialized iterator of type \tcode{I}.
 
 \indexlibrary{\idxcode{counted_iterator}!constructor}%
 \begin{itemdecl}
-counted_iterator(I i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+counted_iterator(I i, difference_type_t<I> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5329,15 +4717,13 @@ counted_iterator(I i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
 
 \indexlibrary{\idxcode{counted_iterator}!constructor}%
 \begin{itemdecl}
-@\oldtxt{template <WeakIterator U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
-counted_iterator(const counted_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@>& @\oldtxt{u}\newtxt{i}@);
+counted_iterator(const counted_iterator<ConvertibleTo<I>>& i);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Constructs a \tcode{counted_iterator}, initializing
-\tcode{current} with \tcode{\oldtxt{u.base()}\newtxt{i.current}} and \tcode{cnt} with \tcode{\oldtxt{u.count()}\newtxt{i.cnt}}.
+\tcode{current} with \tcode{i.current} and \tcode{cnt} with \tcode{i.cnt}.
 \end{itemdescr}
 
 \rSec4[counted.iter.op=]{\tcode{counted_iterator::operator=}}
@@ -5345,15 +4731,13 @@ counted_iterator(const counted_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@>& 
 \indexlibrary{\idxcode{operator=}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator=}}%
 \begin{itemdecl}
-@\oldtxt{template <WeakIterator U>}@
-  @\oldtxt{requires ConvertibleTo<U, I>()}@
-counted_iterator& operator=(const counted_iterator<@\oldtxt{U}\newtxt{ConvertibleTo<I>}@>& @\oldtxt{u}\newtxt{i}@);
+counted_iterator& operator=(const counted_iterator<ConvertibleTo<I>>& i);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{\oldtxt{u.base()}\newtxt{i.current}} to
-\tcode{current} and \tcode{\oldtxt{u.count()}\newtxt{i.cnt}} to \tcode{cnt}.
+\effects Assigns \tcode{i.current} to
+\tcode{current} and \tcode{i.cnt} to \tcode{cnt}.
 
 \end{itemdescr}
 
@@ -5375,7 +4759,7 @@ I base() const;
 \indexlibrary{\idxcode{count}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{count}}%
 \begin{itemdecl}
-@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> count() const;
+difference_type_t<I> count() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5388,14 +4772,13 @@ I base() const;
 \indexlibrary{\idxcode{operator*}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator*}}%
 \begin{itemdecl}
-@\newtxt{decltype(auto) operator*();}@
-@\oldtxt{reference}\newtxt{decltype(auto)}@ operator*() const;
+decltype(auto) operator*();
+decltype(auto) operator*() const;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{*current}.
 \end{itemdescr}
 
@@ -5412,7 +4795,7 @@ counted_iterator& operator++();
 \requires \tcode{cnt > 0}
 
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 ++current;
 @\dcr@cnt;
@@ -5433,7 +4816,7 @@ counted_iterator operator++(int);
 \requires \tcode{cnt > 0}
 
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 counted_iterator tmp = *this;
 ++current;
@@ -5453,7 +4836,7 @@ return tmp;
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 --current;
 ++cnt;
@@ -5472,7 +4855,7 @@ return tmp;
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to}
+\effects Equivalent to
 \begin{codeblock}
 counted_iterator tmp = *this;
 --current;
@@ -5495,8 +4878,7 @@ return tmp;
 \requires \tcode{n <= cnt}
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{counted_iterator(current + n, cnt - n)}.
 \end{itemdescr}
 
@@ -5538,8 +4920,7 @@ cnt -= n;
 \requires \tcode{-n <= cnt}
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{counted_iterator(current - n, cnt + n)}.
 \end{itemdescr}
 
@@ -5572,7 +4953,7 @@ cnt += n;
 \indexlibrary{\idxcode{operator[]}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator[]}}%
 \begin{itemdecl}
-  @\oldoldtxt{\unspec}\newnewtxt{decltype(auto)}@ operator[](difference_type n) const
+  decltype(auto) operator[](difference_type n) const
     requires RandomAccessIterator<I>();
 \end{itemdecl}
 
@@ -5581,8 +4962,7 @@ cnt += n;
 \requires \tcode{n <= cnt}
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{current[n]}.
 \end{itemdescr}
 
@@ -5591,7 +4971,7 @@ cnt += n;
 \indexlibrary{\idxcode{operator==}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator==}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator==(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
@@ -5603,53 +4983,34 @@ template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtx
 sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{x.\oldtxt{count()}\newtxt{cnt} == y.\oldtxt{count()}\newtxt{cnt}}.
+\effects Equivalent to 
+\tcode{x.cnt == y.cnt}.
 \end{itemdescr}
 
 \begin{itemdecl}
-@\oldtxt{template <WeakIterator I>}@
   bool operator==(
-    const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel@\oldtxt{ y}@);
-  @\newtxt{bool operator==(}@
-    @\newtxt{default_sentinel, const counted_iterator<auto>\& x);}@
+    const counted_iterator<auto>& x, default_sentinel);
+  bool operator==(
+    default_sentinel, const counted_iterator<auto>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{x.\oldtxt{count()}\newtxt{cnt} == 0}.
+\effects Equivalent to 
+\tcode{x.cnt == 0}.
 \end{itemdescr}
-
-{\color{oldclr}
-\begin{itemdecl}
-template <WeakIterator I>
-  bool operator==(
-    default_sentinel x, const counted_iterator<I>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to
-\tcode{y.cnt == 0}.
-\end{itemdescr}
-} %% color{oldclr}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator!=(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-@\oldtxt{template <WeakIterator I>}@
   bool operator!=(
-    const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& x, default_sentinel@\oldtxt{ y}@);
-@\oldtxt{template <WeakIterator I>}@
+    const counted_iterator<auto>& x, default_sentinel);
   bool operator!=(
-    default_sentinel@\oldtxt{ x}@, const counted_iterator<@\oldtxt{I}\newtxt{auto}@>& @\oldtxt{y}\newtxt{x}@);
+    default_sentinel, const counted_iterator<auto>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5658,15 +5019,14 @@ template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtx
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{!(x == y)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator<}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator<(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
@@ -5678,116 +5038,68 @@ template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtx
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{y.\oldtxt{count()}\newtxt{cnt} < x.\oldtxt{count()}\newtxt{cnt}}.
+\effects Equivalent to 
+\tcode{y.cnt < x.cnt}.
 
-\newtxt{
 \note The argument order in the \textit{Effects} clause is reversed because \tcode{cnt}
 counts down, not up.
-}
+
 \end{itemdescr}
-
-{\color{oldclr}
-\begin{itemdecl}
-template <WeakIterator I>
-  bool operator<(
-    const counted_iterator<I>& x, default_sentinel y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{x.count() != 0}.
-\end{itemdescr}
-
-\begin{itemdecl}
-template <WeakIterator I>
-  bool operator<(
-    default_sentinel x, const counted_iterator<I>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{false}.
-\end{itemdescr}
-} %% color{oldclr}
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator<=}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator<=(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator<=(}@
-    @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator<=(}@
-    @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \oldtxt{For the first overload, }\tcode{x} and {y} shall refer to
+\requires \tcode{x} and {y} shall refer to
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator>}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator>(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator>(}@
-    @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator>(}@
-    @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \oldtxt{For the first overload, }\tcode{x} and {y} shall refer to
+\requires \tcode{x} and {y} shall refer to
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator>=}}%
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+template <class I1, class I2>
     requires Common<I1, I2>()
   bool operator>=(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator>=(}@
-    @\oldtxt{const counted_iterator<I>\& x, default_sentinel y);}@
-@\oldtxt{template <WeakIterator I>}@
-  @\oldtxt{bool operator>=(}@
-    @\oldtxt{default_sentinel x, const counted_iterator<I>\& y);}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \oldtxt{For the first overload, }\tcode{x} and {y} shall refer to
+\requires \tcode{x} and {y} shall refer to
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{!(x < y)}.
 \end{itemdescr}
 
@@ -5796,47 +5108,44 @@ elements of the same sequence~(\ref{iterators.counted}).
 \indexlibrary{\idxcode{operator-}!\idxcode{counted_iterator}}%
 \indexlibrary{\idxcode{counted_iterator}!\idxcode{operator-}}%
 \begin{itemdecl}
-  template <@\oldtxt{WeakIterator}\newtxt{class}@ I1, @\oldtxt{WeakIterator}\newtxt{class}@ I2>
+  template <class I1, class I2>
       requires Common<I1, I2>()
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I2> operator-(
+  difference_type_t<I2> operator-(
     const counted_iterator<I1>& x, const counted_iterator<I2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \oldtxt{For the first overload, }\tcode{x} and {y} shall refer to
+\requires \tcode{x} and {y} shall refer to
 elements of the same sequence~(\ref{iterators.counted}).
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{y.\oldtxt{count()}\newtxt{cnt} - x.\oldtxt{count()}\newtxt{cnt}}.
+\effects Equivalent to 
+\tcode{y.cnt - x.cnt}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+template <class I>
+  difference_type_t<I> operator-(
     const counted_iterator<I>& x, default_sentinel y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{-x.\oldtxt{count()}\newtxt{cnt}}.
+\effects Equivalent to 
+\tcode{-x.cnt}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
-  @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> operator-(
+template <class I>
+  difference_type_t<I> operator-(
     default_sentinel x, const counted_iterator<I>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
-\tcode{y.\oldtxt{count()}\newtxt{cnt}}.
+\effects Equivalent to 
+\tcode{y.cnt}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator+}!\idxcode{counted_iterator}}%
@@ -5844,23 +5153,22 @@ template <@\oldtxt{WeakIterator}\newtxt{class}@ I>
 \begin{itemdecl}
 template <RandomAccessIterator I>
   counted_iterator<I>
-    operator+(@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n, const counted_iterator<I>& x);
+    operator+(difference_type_t<I> n, const counted_iterator<I>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{n <= x.\oldtxt{count()}\newtxt{cnt}}.
+\requires \tcode{n <= x.cnt}.
 
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{x + n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_counted_iterator}}%
 \begin{itemdecl}
-template <@\oldtxt{Weak}@Iterator I>
-  counted_iterator<I> make_counted_iterator(I i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+template <Iterator I>
+  counted_iterator<I> make_counted_iterator(I i, difference_type_t<I> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5873,51 +5181,20 @@ template <@\oldtxt{Weak}@Iterator I>
 
 \indexlibrary{\idxcode{advance}}%
 \begin{itemdecl}
-template <@\oldtxt{Weak}@Iterator I>
-  void advance(counted_iterator<I>& i, @\oldtxt{DifferenceType}\newtxt{difference_type_t}@<I> n);
+template <Iterator I>
+  void advance(counted_iterator<I>& i, difference_type_t<I> n);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{n <= i.\oldtxt{count()}\newtxt{cnt}}.
+\requires \tcode{n <= i.cnt}.
 
 \pnum
 \effects
 \begin{codeblock}
-i = make_counted_iterator(next(i.@\oldtxt{base()}\newtxt{current}@, n), i.@\oldtxt{count()}\newtxt{cnt}@ - n);
+i = make_counted_iterator(next(i.current, n), i.cnt - n);
 \end{codeblock}
 \end{itemdescr}
-
-{\color{oldclr}
-\rSec3[counted.traits.specializations]{Specializations of \tcode{common_type}}
-
-\indexlibrary{\idxcode{common_type}}%
-\begin{itemdecl}
-namespace std {
-  template<experimental::ranges_v1::WeakIterator I>
-  struct common_type<experimental::ranges_v1::counted_iterator<I>,
-                     experimental::ranges_v1::default_sentinel> {
-    using type = experimental::ranges_v1::common_iterator<
-      experimental::ranges_v1::counted_iterator<I>,
-      experimental::ranges_v1::default_sentinel>;
-  };
-  template<experimental::ranges_v1::WeakIterator I>
-  struct common_type<experimental::ranges_v1::default_sentinel,
-                     experimental::ranges_v1::counted_iterator<I>> {
-    using type = experimental::ranges_v1::common_iterator<
-      experimental::ranges_v1::counted_iterator<I>,
-      experimental::ranges_v1::default_sentinel>;
-  };
-}
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\enternote By specializing \tcode{common_type} this way, \tcode{counted_iterator}
-and \tcode{default_sentinel} can satisfy the \tcode{Common} requirement of the
-\tcode{EqualityComparable} concept.\exitnote
-\end{itemdescr}
-} %% color{oldclr}
 
 \rSec2[dangling.wrappers]{Dangling wrapper}
 
@@ -5929,7 +5206,7 @@ Class template \tcode{dangling} is a wrapper for an object that refers to anothe
 lifetime may have ended. It is used by algorithms that accept rvalue ranges and return iterators.
 
 \begin{codeblock}
-namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\{ inline namespace v1}@ {
+namespace std { namespace experimental { namespace ranges { inline namespace v1 {
   template <CopyConstructible T>
   class dangling {
   public:
@@ -5943,9 +5220,9 @@ namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\
   template <Range R>
   using safe_iterator_t =
     conditional_t<is_lvalue_reference<R>::value,
-      @\oldtxt{IteratorType}\newtxt{iterator_t}@<R>,
-      dangling<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>>>;
-}}}@\newtxt{\}}@
+      iterator_t<R>,
+      dangling<iterator_t<R>>>;
+}}}}
 \end{codeblock}
 
 \rSec3[dangling.wrap.ops]{\tcode{dangling} operations}
@@ -5959,7 +5236,7 @@ dangling() requires DefaultConstructible<T>();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{dangling}, value\newtxt{-}initializing \tcode{value}.
+\effects Constructs a \tcode{dangling}, value-initializing \tcode{value}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{dangling}!\idxcode{dangling}}%
@@ -6003,24 +5280,22 @@ char* nl = find(p, unreachable(), '@\textbackslash@n');
 \end{codeblock}
 
 Provided a newline character really exists in the buffer, the use of \tcode{unreachable}
-above potentially make\newtxt{s} the call to \tcode{find} more efficient since the loop test against
+above potentially makes the call to \tcode{find} more efficient since the loop test against
 the sentinel does not require a conditional branch.
 \exitexample
 
 \begin{codeblock}
-namespace std { namespace experimental { namespace ranges@\oldtxt{_v1} \newtxt{\{ inline namespace v1}@ {
+namespace std { namespace experimental { namespace ranges { inline namespace v1 {
   class unreachable { };
   template <Iterator I>
     constexpr bool operator==(const I&, unreachable) noexcept;
   template <Iterator I>
     constexpr bool operator==(unreachable, const I&) noexcept;
-  @\oldtxt{constexpr bool operator==(unreachable, unreachable) noexcept;}@
   template <Iterator I>
     constexpr bool operator!=(const I&, unreachable) noexcept;
   template <Iterator I>
     constexpr bool operator!=(unreachable, const I&) noexcept;
-  @\oldtxt{constexpr bool operator!=(unreachable, unreachable) noexcept;}@
-}}}@\newtxt{\}}@
+}}}}
 \end{codeblock}
 
 \rSec3[unreachable.sentinel.ops]{\tcode{unreachable} operations}
@@ -6041,17 +5316,6 @@ template <Iterator I>
 \returns \tcode{false}.
 \end{itemdescr}
 
-{\color{oldclr}
-\begin{itemdecl}
-constexpr bool operator==(unreachable, unreachable) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{true}.
-\end{itemdescr}
-} %% color{oldclr}
-
 \rSec4[unreachable.sentinel.op!=]{\tcode{operator!=}}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{unreachable}}%
@@ -6061,39 +5325,13 @@ template <Iterator I>
   constexpr bool operator!=(const I& x, unreachable y) noexcept;
 template <Iterator I>
   constexpr bool operator!=(unreachable x, const I& y) noexcept;
-@\oldtxt{constexpr bool operator!=(unreachable x, unreachable y) noexcept;}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\oldtxt{\tcode{!(x == y)}}\newtxt{\tcode{true}.}
+\tcode{true}.
 \end{itemdescr}
-
-{\color{oldclr}
-\rSec3[unreachable.traits.specializations]{Specializations of \tcode{common_type}}
-
-\indexlibrary{\idxcode{common_type}}%
-\begin{itemdecl}
-namespace std {
-  template<experimental::ranges_v1::Iterator I>
-  struct common_type<I, experimental::ranges_v1::unreachable> {
-    using type = experimental::ranges_v1::common_iterator<I, experimental::ranges_v1::unreachable>;
-  };
-  template<experimental::ranges_v1::Iterator I>
-  struct common_type<experimental::ranges_v1::unreachable, I> {
-    using type = experimental::ranges_v1::common_iterator<I, experimental::ranges_v1::unreachable>;
-  };
-}
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\enternote By specializing \tcode{common_type} this way, any iterator and
-\tcode{unreachable} can satisfy the \tcode{Common} requirement of the
-\tcode{EqualityComparable} concept.\exitnote
-\end{itemdescr}
-} %% color{oldclr}
 \end{addedblock}
 
 \rSec1[iterators.stream]{Stream iterators}
@@ -6166,7 +5404,7 @@ equal to a non-end-of-stream iterator.
 Two non-end-of-stream iterators are equal when they are constructed from the same stream.
 
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1}} \newtxt{\{ inline namespace v1 \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class T, class charT = char, class traits = char_traits<charT>,
       class Distance = ptrdiff_t>
   class istream_iterator@\removed{:}@
@@ -6181,15 +5419,15 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1}} 
     typedef traits traits_type;
     typedef basic_istream<charT, traits> istream_type;
     @\seebelow@ istream_iterator();
-    @\newtxt{\seebelow}@ @\newtxt{istream_iterator(default_sentinel);}@
+    @\seebelow@ istream_iterator(default_sentinel);
     istream_iterator(istream_type& s);
     istream_iterator(const istream_iterator& x) = default;
    ~istream_iterator() = default;
 
     const T& operator*() const;
     const T* operator->() const;
-    istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@& operator++();
-    istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@  operator++(int);
+    istream_iterator@\removed{<T, charT, traits, Distance>}@& operator++();
+    istream_iterator@\removed{<T, charT, traits, Distance>}@  operator++(int);
   private:
     basic_istream<charT, traits>* in_stream; // \expos
     T value;                                 // \expos
@@ -6198,41 +5436,40 @@ namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1}} 
   template <class T, class charT, class traits, class Distance>
     bool operator==(const istream_iterator<T, charT, traits, Distance>& x,
             const istream_iterator<T, charT, traits, Distance>& y);
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator==(default_sentinel x,}@
-            @\newtxt{const istream_iterator<T, charT, traits, Distance>\& y);}@
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator==(const istream_iterator<T, charT, traits, Distance>\& x,}@
-            @\newtxt{default_sentinel y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator==(default_sentinel x,}@
+            @\added{const istream_iterator<T, charT, traits, Distance>\& y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator==(const istream_iterator<T, charT, traits, Distance>\& x,}@
+            @\added{default_sentinel y);}@
   template <class T, class charT, class traits, class Distance>
     bool operator!=(const istream_iterator<T, charT, traits, Distance>& x,
             const istream_iterator<T, charT, traits, Distance>& y);
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator!=(default_sentinel x,}@
-            @\newtxt{const istream_iterator<T, charT, traits, Distance>\& y);}@
-  @\newtxt{template <class T, class charT, class traits, class Distance>}@
-    @\newtxt{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
-            @\newtxt{default_sentinel y);}@
-}@\added{\}\}}\newtxt{\}}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator!=(default_sentinel x,}@
+            @\added{const istream_iterator<T, charT, traits, Distance>\& y);}@
+  @\added{template <class T, class charT, class traits, class Distance>}@
+    @\added{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
+            @\added{default_sentinel y);}@
+}@\added{\}\}\}\}}@
 \end{codeblock}
 
 \rSec3[istream.iterator.cons]{\tcode{istream_iterator} constructors and destructor}
 
-
 \indexlibrary{\idxcode{istream_iterator}!constructor}%
 \begin{itemdecl}
 @\seebelow@ istream_iterator();
-@\newtxt{\seebelow}@ @\newtxt{istream_iterator(default_sentinel);}@
+@\seebelow@ istream_iterator(default_sentinel);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Constructs the end-of-stream iterator. If \tcode{T} is a literal type, then \oldoldtxt{this}\newnewtxt{these}
-constructor\newnewtxt{s} shall be\oldoldtxt{ a} \tcode{constexpr} constructor\newnewtxt{s}.
+Constructs the end-of-stream iterator. If \tcode{T} is a literal type, then \changed{this}{these}
+constructor\added{s} shall be\removed{ a} \tcode{constexpr} constructor\added{s}.
 
 \pnum
-\postcondition \tcode{in_stream == \oldoldtxt{0}\newnewtxt{nullptr}}.
+\postcondition \tcode{in_stream == \changed{0}{nullptr}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{istream_iterator}!constructor}%
@@ -6297,20 +5534,19 @@ const T* operator->() const;
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \changed{\tcode{\&(operator*())}}{\tcode{std::addressof(operator*())}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{istream_iterator}}%
 \indexlibrary{\idxcode{istream_iterator}!\idxcode{operator++}}%
 \begin{itemdecl}
-istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@& operator++();
+istream_iterator@\removed{<T, charT, traits, Distance>}@& operator++();
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{in_stream != \oldoldtxt{0}\newnewtxt{nullptr}}.
+\requires \tcode{in_stream != \changed{0}{nullptr}}.
 
 \pnum
 \effects
@@ -6324,19 +5560,19 @@ istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@& operator++();
 \indexlibrary{\idxcode{operator++}!\idxcode{istream_iterator}}%
 \indexlibrary{\idxcode{istream_iterator}!\idxcode{operator++}}%
 \begin{itemdecl}
-istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@ operator++(int);
+istream_iterator@\removed{<T, charT, traits, Distance>}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{in_stream != \oldoldtxt{0}\newnewtxt{nullptr}}.
+\requires \tcode{in_stream != \changed{0}{nullptr}}.
 
 \pnum
 \effects
 \begin{codeblock}
-istream_iterator@\oldoldtxt{<T, charT, traits, Distance>}@ tmp = *this;
+istream_iterator@\removed{<T, charT, traits, Distance>}@ tmp = *this;
 *in_stream >> value;
-return @\oldoldtxt{(}@tmp@\oldoldtxt{)}@;
+return @\removed{(}@tmp@\removed{)}@;
 \end{codeblock}
 \end{itemdescr}
 
@@ -6355,7 +5591,7 @@ template <class T, class charT, class traits, class Distance>
 \indexlibrary{\idxcode{istream_iterator}!\idxcode{operator==}}
 \end{itemdescr}
 
-{\color{newclr}
+\begin{addedblock}
 \begin{itemdecl}
 template <class T, class charT, class traits, class Distance>
   bool operator==(default_sentinel x,
@@ -6379,7 +5615,7 @@ template <class T, class charT, class traits, class Distance>
 \returns
 \tcode{x.in_stream == nullptr}.%
 \end{itemdescr}
-}
+\end{addedblock}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{istream_iterator}}%
 \indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
@@ -6387,12 +5623,12 @@ template <class T, class charT, class traits, class Distance>
 template <class T, class charT, class traits, class Distance>
   bool operator!=(const istream_iterator<T, charT, traits, Distance>& x,
                   const istream_iterator<T, charT, traits, Distance>& y);
-@\newtxt{template <class T, class charT, class traits, class Distance>}@
-  @\newtxt{bool operator!=(default_sentinel x,}@
-                  @\newtxt{const istream_iterator<T, charT, traits, Distance>\& y);}@
-@\newtxt{template <class T, class charT, class traits, class Distance>}@
-  @\newtxt{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
-                  @\newtxt{default_sentinel y);}@
+@\added{template <class T, class charT, class traits, class Distance>}@
+  @\added{bool operator!=(default_sentinel x,}@
+                  @\added{const istream_iterator<T, charT, traits, Distance>\& y);}@
+@\added{template <class T, class charT, class traits, class Distance>}@
+  @\added{bool operator!=(const istream_iterator<T, charT, traits, Distance>\& x,}@
+                  @\added{default_sentinel y);}@
 \end{itemdecl}
 
 \indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
@@ -6430,31 +5666,30 @@ while (first != last)
 is defined as:
 
 \begin{codeblock}
-namespace std { @\added{namespace experimental \{ namespace ranges\oldtxt{_v1} \newtxt{\{ inline namespace v1} \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class T, class charT = char, class traits = char_traits<charT>>
   class ostream_iterator@\removed{:}@
     @\removed{public iterator<output_iterator_tag, void, void, void, void>}@ {
   public:
-    @\oldtxt{typedef output_iterator_tag iterator_category;}@
     @\added{typedef ptrdiff_t difference_type;}@
     typedef charT char_type;
     typedef traits traits_type;
     typedef basic_ostream<charT, traits> ostream_type;
     @\added{constexpr ostream_iterator() noexcept;}@
-    ostream_iterator(ostream_type& s) @\newtxt{noexcept}@;
-    ostream_iterator(ostream_type& s, const charT* delimiter) @\newtxt{noexcept}@;
-    ostream_iterator(const ostream_iterator@\oldoldtxt{<T, charT, traits>}@& x) @\newtxt{noexcept}@;
+    ostream_iterator(ostream_type& s) noexcept;
+    ostream_iterator(ostream_type& s, const charT* delimiter) noexcept;
+    ostream_iterator(const ostream_iterator@\removed{<T, charT, traits>}@& x) noexcept;
    ~ostream_iterator();
-    ostream_iterator@\oldoldtxt{<T, charT, traits>}@& operator=(const T& value);
+    ostream_iterator@\removed{<T, charT, traits>}@& operator=(const T& value);
 
-    ostream_iterator@\oldoldtxt{<T, charT, traits>}@& operator*();
-    ostream_iterator@\oldoldtxt{<T, charT, traits>}@& operator++();
-    ostream_iterator@\oldoldtxt{<T, charT, traits>\&}@ operator++(int);
+    ostream_iterator@\removed{<T, charT, traits>}@& operator*();
+    ostream_iterator@\removed{<T, charT, traits>}@& operator++();
+    ostream_iterator@\removed{<T, charT, traits>\&}@ operator++(int);
   private:
     basic_ostream<charT, traits>* out_stream;  // \expos
     const charT* delim;                        // \expos
   };
-}@\added{\}\}}\newtxt{\}}@
+}@\added{\}\}}\}@
 \end{codeblock}
 
 \rSec3[ostream.iterator.cons.des]{\tcode{ostream_iterator} constructors and destructor}
@@ -6468,24 +5703,24 @@ constexpr ostream_iterator() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{out_stream} and \tcode{delim} with \oldtxt{null}\newtxt{\tcode{nullptr}}.
+Initializes \tcode{out_stream} and \tcode{delim} with \removed{null}\added{\tcode{nullptr}}.
 \end{itemdescr}
 \end{addedblock}
 
 \indexlibrary{\idxcode{ostream_iterator}!constructor}%
 \begin{itemdecl}
-ostream_iterator(ostream_type& s) @\newtxt{noexcept}@;
+ostream_iterator(ostream_type& s) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{out_stream} with \tcode{\&s} and \tcode{delim} with \oldtxt{null}\newtxt{\tcode{nullptr}}.
+Initializes \tcode{out_stream} with \tcode{\&s} and \tcode{delim} with \removed{null}\added{\tcode{nullptr}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{ostream_iterator}!constructor}%
 \begin{itemdecl}
-ostream_iterator(ostream_type& s, const charT* delimiter) @\newtxt{noexcept}@;
+ostream_iterator(ostream_type& s, const charT* delimiter) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6496,7 +5731,7 @@ Initializes \tcode{out_stream} with \tcode{\&s} and \tcode{delim} with \tcode{de
 
 \indexlibrary{\idxcode{ostream_iterator}!constructor}%
 \begin{itemdecl}
-ostream_iterator(const ostream_iterator& x) @\newtxt{noexcept}@;
+ostream_iterator(const ostream_iterator& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6526,18 +5761,13 @@ ostream_iterator& operator=(const T& value);
 
 \begin{itemdescr}
 \pnum
-\effects \newtxt{Equivalent to:}
+\effects Equivalent to:
 \begin{codeblock}
 *out_stream << value;
-if(delim != @\oldoldtxt{0}\newnewtxt{nullptr}@)
+if(delim != @\changed{0}{nullptr}@)
   *out_stream << delim;
-return @\oldtxt{(}@*this@\oldtxt{)}@;
+return @\removed{(}@*this@\removed{)}@;
 \end{codeblock}
-
-{\color{oldclr}
-\pnum
-\requires \tcode{out_stream != 0}.
-} %%\color{oldclr}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator*}!\idxcode{ostream_iterator}}%
@@ -6556,7 +5786,7 @@ ostream_iterator& operator*();
 \indexlibrary{\idxcode{ostream_iterator}!\idxcode{operator++}}%
 \begin{itemdecl}
 ostream_iterator& operator++();
-ostream_iterator@\oldoldtxt{\&}@ operator++(int);
+ostream_iterator@\removed{\&}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6589,7 +5819,7 @@ iterator value.
 The default constructor
 \tcode{istreambuf_iterator()}
 and the constructor
-\tcode{istreambuf_iterator(\oldoldtxt{0}\newnewtxt{nullptr})}
+\tcode{istreambuf_iterator(\changed{0}{nullptr})}
 both construct an end-of-stream iterator object suitable for use
 as an end-of-range.
 All specializations of \tcode{istreambuf_iterator} shall have a trivial copy
@@ -6606,8 +5836,9 @@ value is returned.
 It is impossible to assign a character via an input iterator.
 
 \indexlibrary{\idxcode{istreambuf_iterator}}%
+
 \begin{codeblock}
-namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} \{ inline namespace v1 \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template<class charT, class traits = char_traits<charT>>
   class istreambuf_iterator
      @\removed{: public iterator<input_iterator_tag, charT,}@
@@ -6627,7 +5858,7 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} 
     class proxy;                           // \expos
 
     constexpr istreambuf_iterator() noexcept;
-    @\newtxt{constexpr istreambuf_iterator(default_sentinel) noexcept;}@
+    constexpr istreambuf_iterator(default_sentinel) noexcept;
     istreambuf_iterator(const istreambuf_iterator&) noexcept = default;
     ~istreambuf_iterator() = default;
     istreambuf_iterator(istream_type& s) noexcept;
@@ -6635,7 +5866,7 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} 
     istreambuf_iterator(const proxy& p) noexcept;
     charT operator*() const;
     pointer operator->() const;
-    istreambuf_iterator@\oldoldtxt{<charT, traits>}@& operator++();
+    istreambuf_iterator@\removed{<charT, traits>}@& operator++();
     proxy operator++(int);
     bool equal(const istreambuf_iterator& b) const;
   private:
@@ -6645,29 +5876,29 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} 
   template <class charT, class traits>
     bool operator==(const istreambuf_iterator<charT, traits>& a,
             const istreambuf_iterator<charT, traits>& b);
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator==(default_sentinel a,}@
-            @\newtxt{const istreambuf_iterator<charT, traits>\& b);}@
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator==(const istreambuf_iterator<charT, traits>\& a,}@
-            @\newtxt{default_sentinel b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator==(default_sentinel a,}@
+            @\added{const istreambuf_iterator<charT, traits>\& b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator==(const istreambuf_iterator<charT, traits>\& a,}@
+            @\added{default_sentinel b);}@
   template <class charT, class traits>
     bool operator!=(const istreambuf_iterator<charT, traits>& a,
             const istreambuf_iterator<charT, traits>& b);
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator!=(default_sentinel a,}@
-            @\newtxt{const istreambuf_iterator<charT, traits>\& b);}@
-  @\newtxt{template <class charT, class traits>}@
-    @\newtxt{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
-            @\newtxt{default_sentinel b);}@
-}@\newtxt{\}\}\}}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator!=(default_sentinel a,}@
+            @\added{const istreambuf_iterator<charT, traits>\& b);}@
+  @\added{template <class charT, class traits>}@
+    @\added{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
+            @\added{default_sentinel b);}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \rSec3[istreambuf.iterator::proxy]{Class template \tcode{istreambuf_iterator::proxy}}
 
 \indexlibrary{\idxcode{proxy}!\idxcode{istreambuf_iterator}}%
 \begin{codeblock}
-namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} \{ inline namespace v1 \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class charT, class traits = char_traits<charT> >
   class istreambuf_iterator<charT, traits>::proxy { // \expos
     charT keep_;
@@ -6677,7 +5908,7 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} 
   public:
     charT operator*() { return keep_; }
   };
-}@\newtxt{\}\}\}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \pnum
@@ -6700,7 +5931,7 @@ of the iterator for some possible future access to get the character.
 \indexlibrary{\idxcode{istreambuf_iterator}!constructor}%
 \begin{itemdecl}
 constexpr istreambuf_iterator() noexcept;
-@\newtxt{constexpr istreambuf_iterator(default_sentinel) noexcept;}@
+constexpr istreambuf_iterator(default_sentinel) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6770,13 +6001,13 @@ member
 
 \indexlibrary{\idxcode{operator++}!\idxcode{istreambuf_iterator}}%
 \begin{itemdecl}
-istreambuf_iterator@\oldoldtxt{<charT, traits>}@&
+istreambuf_iterator@\removed{<charT, traits>}@&
     istreambuf_iterator<charT, traits>::operator++();
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects \newnewtxt{Equivalent to }
+\effects \added{Equivalent to }
 \tcode{sbuf_->sbumpc()}.
 
 \pnum
@@ -6792,8 +6023,7 @@ proxy istreambuf_iterator<charT, traits>::operator++(int);
 
 \begin{itemdescr}
 \pnum
-\oldtxt{\returns}
-\newtxt{\effects Equivalent to }
+\effects Equivalent to 
 \tcode{proxy(sbuf_->sbumpc(), sbuf_)}.
 \end{itemdescr}
 
@@ -6801,7 +6031,7 @@ proxy istreambuf_iterator<charT, traits>::operator++(int);
 
 \indexlibrary{\idxcode{equal}!\idxcode{istreambuf_iterator}}%
 \begin{itemdecl}
-bool equal(const istreambuf_iterator@\oldoldtxt{<charT, traits>}@& b) const;
+bool equal(const istreambuf_iterator@\removed{<charT, traits>}@& b) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6825,12 +6055,12 @@ template <class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{\returns}
-\newnewtxt{\effects Equivalent to}
+\removed{\returns}
+\added{\effects Equivalent to}
 \tcode{a.equal(b)}.
 \end{itemdescr}
 
-{\color{newclr}
+\begin{addedblock}
 \begin{itemdecl}
 template <class charT, class traits>
   bool operator==(default_sentinel a,
@@ -6854,7 +6084,7 @@ template <class charT, class traits>
 \effects Equivalent to
 \tcode{a.equal(istreambuf_iterator<charT, traits>\{\})}.
 \end{itemdescr}
-} %% color{newclr}
+\end{addedblock}
 
 \rSec3[istreambuf.iterator::op!=]{\tcode{operator!=}}
 
@@ -6863,21 +6093,21 @@ template <class charT, class traits>
 template <class charT, class traits>
   bool operator!=(const istreambuf_iterator<charT, traits>& a,
                   const istreambuf_iterator<charT, traits>& b);
-@\newnewtxt{template <class charT, class traits>}@
-  @\newnewtxt{bool operator!=(default_sentinel a,}@
-                  @\newnewtxt{const istreambuf_iterator<charT, traits>\& b);}@
-@\newnewtxt{template <class charT, class traits>}@
-  @\newnewtxt{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
-                  @\newnewtxt{default_sentinel b);}@
+@\added{template <class charT, class traits>}@
+  @\added{bool operator!=(default_sentinel a,}@
+                  @\added{const istreambuf_iterator<charT, traits>\& b);}@
+@\added{template <class charT, class traits>}@
+  @\added{bool operator!=(const istreambuf_iterator<charT, traits>\& a,}@
+                  @\added{default_sentinel b);}@
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\oldoldtxt{
+\removed{
 \returns
 \tcode{!a.equal(b)}.
 }
-\newnewtxt{
+\added{
 \effects Equivalent to
 \tcode{!(a == b)}
 }
@@ -6887,19 +6117,19 @@ template <class charT, class traits>
 
 \indexlibrary{\idxcode{ostreambuf_iterator}}%
 \begin{codeblock}
-namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} \{ inline namespace v1 \{}@
+namespace std { @\added{namespace experimental \{ namespace ranges \{ inline namespace v1 \{}@
   template <class charT, class traits = char_traits<charT> >
   class ostreambuf_iterator @\removed{:}@
     @\removed{public iterator<output_iterator_tag, void, void, void, void>}@ {
   public:
-    @\oldoldtxt{typedef output_iterator_tag}@            @\oldoldtxt{iterator_category;}@
+    @\removed{typedef output_iterator_tag}@            @\removed{iterator_category;}@
     @\added{typedef ptrdiff_t}@                      @\added{difference_type;}@
     typedef charT                          char_type;
     typedef traits                         traits_type;
     typedef basic_streambuf<charT, traits> streambuf_type;
     typedef basic_ostream<charT, traits>   ostream_type;
 
-  @\oldoldtxt{public:}@
+  @\removed{public:}@
     @\added{constexpr ostreambuf_iterator() noexcept;}@
     ostreambuf_iterator(ostream_type& s) noexcept;
     ostreambuf_iterator(streambuf_type* s) noexcept;
@@ -6907,13 +6137,13 @@ namespace std { @\newtxt{namespace experimental \{ namespace ranges\oldtxt{_v1} 
 
     ostreambuf_iterator& operator*();
     ostreambuf_iterator& operator++();
-    ostreambuf_iterator@\oldoldtxt{\&}@ operator++(int);
+    ostreambuf_iterator@\removed{\&}@ operator++(int);
     bool failed() const noexcept;
 
   private:
     streambuf_type* sbuf_;                // \expos
   };
-}@\newtxt{\}\}\}}@
+}@\added{\}\}\}}@
 \end{codeblock}
 
 \pnum
@@ -6936,7 +6166,7 @@ constexpr ostreambuf_iterator() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \oldtxt{null}\newtxt{\tcode{nullptr}}.
+Initializes \tcode{sbuf_} with \removed{null}\added{\tcode{nullptr}}.
 \end{itemdescr}
 \end{addedblock}
 
@@ -6948,8 +6178,8 @@ ostreambuf_iterator(ostream_type& s) noexcept;
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{s.rdbuf()\newnewtxt{ != nullptr}}
-\oldoldtxt{shall not null pointer}.
+\tcode{s.rdbuf()\added{ != nullptr}}
+\removed{shall not null pointer}.
 \end{itemdescr}
 
 \begin{itemdescr}
@@ -6966,8 +6196,8 @@ ostreambuf_iterator(streambuf_type* s) noexcept;
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{s\newnewtxt{ != nullptr}}
-\oldoldtxt{shall not be a null pointer}.
+\tcode{s\added{ != nullptr}}
+\removed{shall not be a null pointer}.
 
 \pnum
 \effects
@@ -6978,14 +6208,14 @@ Initializes \tcode{sbuf_} with \tcode{s}.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{ostreambuf_iterator}}%
 \begin{itemdecl}
-ostreambuf_iterator@\oldoldtxt{<charT, traits>}@&
+ostreambuf_iterator@\removed{<charT, traits>}@&
   operator=(charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
 \begin{addedblock}
 \pnum
-\requires \tcode{sbuf_ != \oldoldtxt{0}\newnewtxt{nullptr}}.
+\requires \tcode{sbuf_ != \changed{0}{nullptr}}.
 \end{addedblock}
 
 \pnum
@@ -7005,7 +6235,7 @@ otherwise has no effect.
 
 \indexlibrary{\idxcode{operator*}!\idxcode{ostreambuf_iterator}}%
 \begin{itemdecl}
-ostreambuf_iterator@\oldoldtxt{<charT, traits>}@& operator*();
+ostreambuf_iterator@\removed{<charT, traits>}@& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7016,8 +6246,8 @@ ostreambuf_iterator@\oldoldtxt{<charT, traits>}@& operator*();
 
 \indexlibrary{\idxcode{operator++}!\idxcode{ostreambuf_iterator}}%
 \begin{itemdecl}
-ostreambuf_iterator@\oldoldtxt{<charT, traits>}@& operator++();
-ostreambuf_iterator@\oldoldtxt{<charT, traits>\&}@ operator++(int);
+ostreambuf_iterator@\removed{<charT, traits>}@& operator++();
+ostreambuf_iterator@\removed{<charT, traits>\&}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7034,7 +6264,7 @@ bool failed() const noexcept;
 \begin{itemdescr}
 \begin{addedblock}
 \pnum
-\requires \tcode{sbuf_ != \oldoldtxt{0}\newnewtxt{nullptr}}.
+\requires \tcode{sbuf_ != \changed{0}{nullptr}}.
 \end{addedblock}
 
 \pnum
@@ -7071,7 +6301,7 @@ as summarized in Table~\ref{tab:ranges.lib.summary}.
 
 \begin{libsumtab}{Ranges library summary}{tab:ranges.lib.summary}
   \ref{ranges.requirements} & Requirements      & \\ \rowsep
-  \ref{iterator.range}      & Range access      & \tcode{<\newtxt{experimental/ranges\oldtxt{_v1}/}iterator>} \\
+  \ref{iterator.range}      & Range access      & \tcode{<experimental/ranges/iterator>} \\
   \ref{range.primitives}    & Range primitives  & \\
 \end{libsumtab}
 
@@ -7084,13 +6314,13 @@ Ranges are an abstraction of containers that allow a \Cpp program to
 operate on elements of data structures uniformly. It their simplest form, a
 range object is one on which one can call \tcode{begin} and
 \tcode{end} to get an iterator~(\ref{iterators.iterator}) and a
-sentinel~(\ref{iterators.sentinel})\oldtxt{ or an iterator}. To be able to construct
+sentinel~(\ref{iterators.sentinel}). To be able to construct
 template algorithms and range adaptors that work correctly and efficiently on
 different types of sequences, the library formalizes not just the interfaces but
 also the semantics and complexity assumptions of ranges.
 
 \pnum
-This \oldtxt{International Standard}\newtxt{document} defines three fundamental categories of ranges
+This document defines three fundamental categories of ranges
 based on the syntax and semantics supported by each: \techterm{range},
 \techterm{sized range} and \techterm{view}, as shown in
 Table~\ref{tab:ranges.relations}.
@@ -7107,132 +6337,110 @@ Table~\ref{tab:ranges.relations}.
 
 \pnum
 The \tcode{Range} concept requires only that \tcode{begin} and \tcode{end}
-return an iterator and a sentinel. \oldtxt{\enternote An iterator is a valid sentinel.
-\exitnote} The \tcode{SizedRange} concept refines \tcode{Range} \oldtxt{but adds}
-\newtxt{with} the requirement that the number of elements in the range can be determined
-in constant time \oldtxt{with}\newtxt{using} the \tcode{size} function. The \tcode{View} concept
-\oldtxt{describes}\newtxt{specifies} requirements on an \tcode{Range} type
+return an iterator and a sentinel. The \tcode{SizedRange} concept refines \tcode{Range}
+with the requirement that the number of elements in the range can be determined
+in constant time using the \tcode{size} function. The \tcode{View} concept
+specifies requirements on an \tcode{Range} type
 with constant-time copy and assign operations.
 
 \pnum
-In addition to the three fundamental range categories, this \oldtxt{standard}\newtxt{document} defines
+In addition to the three fundamental range categories, this document defines
 a number of convenience refinements of \tcode{Range} that group together requirements
 that appear often in the concepts, algorithms, and range adaptors.
 \techterm{Bounded ranges} are ranges for which \tcode{begin} and \tcode{end} return objects of the
 same type. \techterm{Random access ranges} are ranges for which
-\tcode{begin} returns a \oldtxt{model of}\newtxt{type that satisfies}
+\tcode{begin} returns a type that satisfies
 \tcode{RandomAccessIterator}~(\ref{iterators.random.access}). The range
 categories \techterm{bidirectional ranges},
 \techterm{forward ranges},
 \techterm{input ranges}, and
 \techterm{output ranges} are defined similarly.
-\oldtxt{\enternote There are no \techterm{weak input ranges} or
-\techterm{weak output ranges} because of the \tcode{EqualityComparable}
-requirement on iterators and sentinels. \exitnote}
 
 \rSec3[ranges.range]{Ranges}
 
 \pnum
 The \tcode{Range} concept defines the requirements of a type that allows
 iteration over its elements by providing a \tcode{begin} iterator and an
-\tcode{end}\oldtxt{ iterator or} sentinel.
+\tcode{end} sentinel.
 \enternote Most algorithms requiring this concept simply forward to an
 \tcode{Iterator}-based algorithm by calling \tcode{begin} and \tcode{end}. \exitnote
 
 \begin{itemdecl}
 template <class T>
-using @\oldtxt{IteratorType}\newtxt{iterator_t}@ = decltype(@\newtxt{ranges::}@begin(declval<T@\newtxt{\&}@>()));
+using iterator_t = decltype(ranges::begin(declval<T&>()));
 
 template <class T>
-using @\oldtxt{SentinelType}\newtxt{sentinel_t}@ = decltype(@\newtxt{ranges::}@end(declval<T@\newtxt{\&}@>()));
+using sentinel_t = decltype(ranges::end(declval<T&>()));
 
 template <class T>
 concept bool Range() {
-  return requires@\oldtxt{(T t)}@ {
-    @\oldtxt{typename IteratorType<T>;}@
-    typename @\oldtxt{SentinelType}\newtxt{sentinel_t}@<T>;
-    @\oldtxt{\{ begin(t) \} -> IteratorType<T>;}@
-    @\oldtxt{\{ end(t) \} -> SentinelType<T>;}@
-    @\oldtxt{requires Sentinel<SentinelType<T>, IteratorType<T>{}>;}@
+  return requires {
+    typename sentinel_t<T>;
   };
-@\newtxt{\}}@
+}
 \end{itemdecl}
 
 \begin{itemdescr}
 
-\oldtxt{\tcode{begin} and \tcode{end} are required to be amortized constant time.}
-
 \pnum
-\newtxt{Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>}, \tcode{Range<T>()} is satisfied
-if and only if}
+Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>}, \tcode{Range<T>()} is satisfied
+if and only if
 
 \begin{itemize}
-\item \newtxt{\range{begin(t)}{end(t)} denotes a range.}
+\item \range{begin(t)}{end(t)} denotes a range.
 
-\item \newtxt{Both \tcode{begin(t)} and \tcode{end(t)} are amortized constant time
+\item Both \tcode{begin(t)} and \tcode{end(t)} are amortized constant time
 and non-modifying. \enternote \tcode{begin(t)} and \tcode{end(t)} do not require
-implicit expression variants. \exitnote}
+implicit expression variants. \exitnote
 
-\item \newtxt{If \tcode{\oldtxt{IteratorType<T>}}\tcode{\newtxt{iterator_t<T>}} satisfies \tcode{ForwardIterator},
-\tcode{begin(t)} is equality preserving.}
+\item If \tcode{iterator_t<T>} satisfies \tcode{ForwardIterator},
+\tcode{begin(t)} is equality preserving.
 \end{itemize}
 \end{itemdescr}
 
-\pnum \newtxt{\enternote
+\pnum \enternote
 Equality preservation of both \tcode{begin} and \tcode{end} enables passing a \tcode{Range}
-whose \tcode{\oldtxt{IteratorType}}iterator type satisfies \tcode{ForwardIterator}
+whose iterator type satisfies \tcode{ForwardIterator}
 to multiple algorithms and
 making multiple passes over the range by repeated calls to \tcode{begin} and \tcode{end}.
 Since \tcode{begin} is not required to be equality preserving when the return type does
 not satisfy \tcode{ForwardIterator}, repeated calls might not return equal values or
 might not be well-defined; \tcode{begin} should be called at most once for such a range.
-\exitnote}
+\exitnote
 
 \rSec3[ranges.sized]{Sized ranges}
 
 \pnum
-The \tcode{SizedRange} concept \oldtxt{describes}\newtxt{specifies} the requirements
+The \tcode{SizedRange} concept specifies the requirements
 of a \tcode{Range} type that knows its size in constant time with the
 \tcode{size} function.
 
 \begin{itemdecl}
-@\oldtxt{// \expos}@
-@\oldtxt{template <class T>}@
-@\oldtxt{concept bool \xname{SizedRangeLike} =}@
-  @\oldtxt{Range<T> \&\&}@
-  @\oldtxt{requires(T t) \{}@
-    @\oldtxt{\{ size(t) \} -> Integral;}@
-    @\oldtxt{requires Convertible<decltype(size(t)),}@
-                         @\oldtxt{DifferenceType<IteratorType<T>{>}{>};}@
-  @\oldtxt{\};}@
-
-@\newtxt{template <class R>}@
-@\newtxt{constexpr bool disable_sized_range = false;}@
+template <class R>
+constexpr bool disable_sized_range = false;
 
 template <class T>
 concept bool SizedRange() {
-  @\oldtxt{\xname{SizedRangeLike}<T> \&\& is_sized_range<T>::value;}@
-  @\newtxt{return Range<T>() \&\&}@
-    @\newtxt{!disable_sized_range<remove_cv_t<remove_reference_t<T>{>}{>} \&\&}@
-    @\newtxt{requires (const remove_reference_t<T>\& t) \{}@
-      @\newtxt{\{ ranges::size(t) \} -> Integral;}@
-      @\newtxt{\{ ranges::size(t) \} -> ConvertibleTo<\oldtxt{DifferenceType}difference_type_t<\oldtxt{IteratorType}iterator_t<T>{>}{>};}@
-    @\newtxt{\};}@
-@\newtxt{\}}@
+  return Range<T>() &&
+    !disable_sized_range<remove_cv_t<remove_reference_t<T>>> &&
+    requires (const remove_reference_t<T>& t) {
+      { ranges::size(t) } -> Integral;
+      { ranges::size(t) } -> ConvertibleTo<difference_type_t<iterator_t<T>>>;
+    };
+}
 \end{itemdecl}
 
 \begin{itemdescr}
-{\color{newclr}
 \pnum
 Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>}, \tcode{SizedRange<T>()} is satisfied if and only if:
 
 \begin{itemize}
 \item \tcode{size(t)} returns the number of elements in \tcode{t}.
-\item If \tcode{\oldtxt{IteratorType}iterator_t<T>} satisfies \tcode{ForwardIterator},
+\item If \tcode{iterator_t<T>} satisfies \tcode{ForwardIterator},
 \tcode{size(t)} is well-defined regardless of the evaluation of
 \tcode{begin(t)}. \enternote \tcode{size(t)} is otherwise not required be
 well-defined after evaluating \tcode{begin(t)}. For a \tcode{SizedRange}
-whose \tcode{\oldtxt{IteratorType}}iterator type does not model \tcode{ForwardIterator}, for
+whose iterator type does not model \tcode{ForwardIterator}, for
 example, \tcode{size(t)} might only be well-defined if evaluated before
 the first call to \tcode{begin(t)}. \exitnote
 \end{itemize}
@@ -7248,48 +6456,12 @@ not in fact satisfy \tcode{SizedRange}.
 diagnostic required unless
 \tcode{disable_sized_range<remove_cv_t<remove_reference_t<R>{>}{>}} evaluates
 to \tcode{true}~(\ref{structure.requirements}). \exitnote
-} %% color{newclr}
-
-{\color{oldclr}
-\pnum
-For any type \tcode{T}, \tcode{disable_sized_range<T>}
-derives from \tcode{false_type} if \tcode{T}
-is a non-reference cv-unqualified type, and from
-\tcode{disable_sized_range<remove_cv_t<remove_reference_t<T>{>}{>}} otherwise.
-
-\pnum
-Users are free to specialize \tcode{disable_sized_range}.
-\enternote Users must specialize
-\tcode{disable_sized_range} so that its member
-\tcode{value} is \tcode{true} to override the default for \tcode{Range} types that meet only the
-syntactic requirements of \tcode{SizedRange} when instantiating a library
-template that has differing behavior for \tcode{Range} and \tcode{SizedRange}. \exitnote
-
-\pnum
-\enternote A possible implementation for
-\tcode{disable_sized_range} is given below:
-
-\begin{codeblock}
-// \expos
-template <class T>
-using @\xname{uncvref}@ = remove_cv_t<remove_reference_t<T>>;
-
-template <class R>
-struct disable_sized_range :
-  disable_sized_range<@\xname{uncvref}@<R>> { };
-
-template <class R>
-  requires Same<R, @\xname{uncvref}@<R>>()
-struct disable_sized_range<R> : false_type { };
-\end{codeblock}
-\exitnote
-} %% color{oldclr}
 \end{itemdescr}
 
 \rSec3[ranges.view]{Views}
 
 \pnum
-The \tcode{View} concept \oldtxt{describes}\newtxt{specifies} the requirements of a
+The \tcode{View} concept specifies the requirements of a
 \tcode{Range} type that has constant time copy, move and assignment operators; that
 is, the cost of these operations is not proportional to the number of elements in
 the \tcode{View}.
@@ -7301,7 +6473,7 @@ Examples of \tcode{View}s are:
 \begin{itemize}
 \item A \tcode{Range} type that wraps a pair of iterators.
 
-\item A \tcode{Range} type that hold\newtxt{s} its elements by \tcode{shared_ptr}
+\item A \tcode{Range} type that holds its elements by \tcode{shared_ptr}
 and shares ownership with all its copies.
 
 \item A \tcode{Range} type that generates its elements on demand.
@@ -7312,121 +6484,79 @@ container copies the elements, which cannot be done in constant time.
 \exitexample
 
 \begin{itemdecl}
-@\newtxt{template <class T>}@
-@\newtxt{struct enable_view \{ \};}@
+template <class T>
+struct enable_view { };
 
-@\newtxt{struct view_base \{ \};}@
+struct view_base { };
 
 // \expos
-@\newtxt{template <class T>}@
-@\newtxt{constexpr bool \xname{view_predicate} = \seebelow;}@
+template <class T>
+constexpr bool @\xname{view_predicate}@ = @\seebelow@;
 
 template <class T>
 concept bool View() {
   return Range<T>() &&
     Semiregular<T>() &&
-    @\oldtxt{is_view}\newtxt{\xname{view_predicate}}@<T>@\oldtxt{::value}@;
-@\newtxt{\}}@
+    @\xname{view_predicate}@<T>;
+}
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Since the difference between \tcode{Range} and \tcode{View} is largely semantic, the
-two are differentiated with the help of the \tcode{\oldtxt{is}\newtxt{enable}_view}
-trait. Users may specialize \oldtxt{the} \tcode{\oldtxt{is}\newtxt{enable}_view}
-\oldtxt{trait} \newtxt{to derive from \tcode{true_type} or \tcode{false_type}}.
-\oldtxt{By default, \tcode{\oldtxt{is_view}\newtxt{\xname{view_predicate}}}
-uses the following heuristics to determine whether a \tcode{Range} type \tcode{T}
-is a \tcode{View}:}
-\begin{itemize}
-\item \oldtxt{If \tcode{T} derives from \tcode{view_base}, \tcode{is_view<T>::value}
-is true.}
-\item \oldtxt{If a top-level \tcode{const} changes \tcode{T}'s \tcode{IteratorType}'s
-\tcode{ReferenceType} type, \tcode{is_view<T>::value}
-is false. \enternote Deep \tcode{const}-ness implies element ownership, whereas shallow
-\tcode{const}-ness implies reference semantics. \exitnote}
-\end{itemize}
+two are differentiated with the help of the \tcode{enable_view}
+trait. Users may specialize \tcode{enable_view}
+to derive from \tcode{true_type} or \tcode{false_type}.
 
-{\color{newclr}
 \pnum
 For a type \tcode{T}, the value of \tcode{\xname{view_predicate<T>}} shall be:
 \begin{itemize}
 \item If \tcode{enable_view<T>} has a member type \tcode{type}, \tcode{enable_view<T>::type::value};
-\item \oldtxt{If}\newtxt{Otherwise, if} \tcode{T} is derived from \tcode{view_base}, \tcode{true};
-\item \newtxt{Otherwise, if \tcode{T} is an instantiation of class template
+\item Otherwise, if \tcode{T} is derived from \tcode{view_base}, \tcode{true};
+\item Otherwise, if \tcode{T} is an instantiation of class template
 \tcode{initializer_list}~(\cxxref{support.initlist}),
 \tcode{set}~(\cxxref{set}),
 \tcode{multiset}~(\cxxref{multiset}),
 \tcode{unordered_set}~(\cxxref{unord.set}), or
-\tcode{unordered_multiset}~(\cxxref{unord.multiset}), \tcode{false}};
-\item \oldtxt{If}\newtxt{Otherwise, if} both \tcode{T} and \tcode{const T} satisfy \tcode{Range} and \tcode{\oldtxt{ReferenceType}reference_t}
-\tcode{<\oldtxt{IteratorType}iterator_t<T>{>}} is not the same type as \tcode{\oldtxt{ReferenceType}reference_t}
-\tcode{<\oldtxt{IteratorType}iterator_t<const T>{>}},
+\tcode{unordered_multiset}~(\cxxref{unord.multiset}), \tcode{false};
+\item Otherwise, if both \tcode{T} and \tcode{const T} satisfy \tcode{Range} and \tcode{reference_t}
+\tcode{<iterator_t<T>{>}} is not the same type as \tcode{reference_t}
+\tcode{<iterator_t<const T>{>}},
 \tcode{false}; \enternote Deep \tcode{const}-ness implies element ownership, whereas shallow \tcode{const}-ness
 implies reference semantics. \exitnote
 \item Otherwise, \tcode{true}.
 \end{itemize}
-} %% color{newclr}
-
-{\color{oldclr}
-\pnum
-\enternote
-Below is a possible implementation of \tcode{\xname{view_predicate}}.
-
-\begin{codeblock}
-// \expos
-template <class T>
-concept bool @\xname{ContainerLike}@ =
-  Range<T>() && Range<const T>() &&
-  !Same<reference_t<iterator_t<T>>,
-        reference_t<iterator_t<const T>>>();
-
-template <class T>
-constexpr bool @\xname{view_predicate}@ = true;
-
-template <class T>
-  requires requires { typename enable_view<T>::type; }
-constexpr bool @\xname{view_predicate}@<T> = enable_view<T>::type::value;
-
-template <@\xname{ContainerLike}@ T>
-  requires !(DerivedFrom<T, view_base>() ||
-             requires { typename enable_view<T>::type; })
-constexpr bool @\xname{view_predicate}@<T> = false;
-\end{codeblock}
-\exitnote
-} %% color{oldclr}
 \end{itemdescr}
 
 \rSec3[ranges.bounded]{Bounded ranges}
 
 \pnum
-The \tcode{BoundedRange} concept \oldtxt{describes}\newtxt{specifies} requirements
+The \tcode{BoundedRange} concept specifies requirements
 of an \tcode{Range} type for which \tcode{begin} and \tcode{end} return objects of
 the same type. \enternote The standard containers~(\cxxref{containers})
-\oldtxt{are models of} \newtxt{satisfy} \tcode{BoundedRange}.\exitnote
+satisfy \tcode{BoundedRange}.\exitnote
 
 \begin{codeblock}
 template <class T>
 concept bool BoundedRange() {
-  return Range<T>() && Same<@\oldtxt{IteratorType}\newtxt{iterator_t}@<T>, @\oldtxt{SentinelType}\newtxt{sentinel_t}@<T>>();
-@\newtxt{\}}@
+  return Range<T>() && Same<iterator_t<T>, sentinel_t<T>>();
+}
 \end{codeblock}
 
 \rSec3[ranges.input]{Input ranges}
 
 \pnum
-The \tcode{InputRange} concept \oldtxt{describes}\newtxt{specifies} requirements of
-an \tcode{Range} type for which \tcode{begin} returns a \oldtxt{model of}\newtxt{type
-that satisfies} \tcode{InputIterator}~(\ref{iterators.input}).
+The \tcode{InputRange} concept specifies requirements of
+an \tcode{Range} type for which \tcode{begin} returns a type
+that satisfies \tcode{InputIterator}~(\ref{iterators.input}).
 
 \begin{codeblock}
 template <class T>
 concept bool InputRange() {
-  return Range<T>() && InputIterator<@\oldtxt{IteratorType}\newtxt{iterator_t}@<T>>();
-@\newtxt{\}}@
+  return Range<T>() && InputIterator<iterator_t<T>>();
+}
 \end{codeblock}
 
-{\color{newclr}
 \rSec3[ranges.output]{Output ranges}
 
 \pnum
@@ -7437,50 +6567,49 @@ an \tcode{Range} type for which \tcode{begin} returns a type that satisfies
 \begin{codeblock}
 template <class R, class T>
 concept bool OutputRange() {
-  return Range<R>() && OutputIterator<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>, T>();
+  return Range<R>() && OutputIterator<iterator_t<R>, T>();
 }
 \end{codeblock}
-}
 
 \rSec3[ranges.forward]{Forward ranges}
 
 \pnum
-The \tcode{ForwardRange} concept \oldtxt{describes}\newtxt{specifies} requirements of an
-\tcode{InputRange} type for which \tcode{begin} returns a \oldtxt{model of}\newtxt{type that satisfies}
+The \tcode{ForwardRange} concept specifies requirements of an
+\tcode{InputRange} type for which \tcode{begin} returns a type that satisfies
 \tcode{ForwardIterator}~(\ref{iterators.forward}).
 
 \begin{codeblock}
 template <class T>
 concept bool ForwardRange() {
-  return InputRange<T>() && ForwardIterator<@\oldtxt{IteratorType}\newtxt{iterator_t}@<T>>();
+  return InputRange<T>() && ForwardIterator<iterator_t<T>>();
 }
 \end{codeblock}
 
 \rSec3[ranges.bidirectional]{Bidirectional ranges}
 
 \pnum
-The \tcode{BidirectionalRange} concept \oldtxt{describes}\newtxt{specifies} requirements of a
-\tcode{ForwardRange} type for which \tcode{begin} returns a \oldtxt{model of}\newtxt{type that satisfies}
+The \tcode{BidirectionalRange} concept specifies requirements of a
+\tcode{ForwardRange} type for which \tcode{begin} returns a type that satisfies
 \tcode{BidirectionalIterator}~(\ref{iterators.bidirectional}).
 
 \begin{codeblock}
 template <class T>
 concept bool BidirectionalRange() {
-  return ForwardRange<T>() && BidirectionalIterator<@\oldtxt{IteratorType}\newtxt{iterator_t}@<T>>();
+  return ForwardRange<T>() && BidirectionalIterator<iterator_t<T>>();
 }
 \end{codeblock}
 
 \rSec3[ranges.random.access]{Random access ranges}
 
 \pnum
-The \tcode{RandomAccessRange} concept \oldtxt{describes}\newtxt{specifies} requirements of a
-\tcode{BidirectionalRange} type for which \tcode{begin} returns a \oldtxt{model of}\newtxt{type that satisfies}
+The \tcode{RandomAccessRange} concept specifies requirements of a
+\tcode{BidirectionalRange} type for which \tcode{begin} returns a type that satisfies
 \tcode{RandomAccessIterator}~(\ref{iterators.random.access}).
 
 \begin{codeblock}
 template <class T>
 concept bool RandomAccessRange() {
-  return BidirectionalRange<T>() && RandomAccessIterator<@\oldtxt{IteratorType}\newtxt{iterator_t}@<T>>();
+  return BidirectionalRange<T>() && RandomAccessIterator<iterator_t<T>>();
 }
 \end{codeblock}
 
@@ -7488,16 +6617,14 @@ concept bool RandomAccessRange() {
 
 \rSec1[iterator.range]{Range access}
 
-{\color{remclr}
+\begin{removedblock}
 \pnum
 In addition to being available via inclusion of the \tcode{<iterator>} header,
 the function templates in \ref{iterator.range} are available when any of the following
 headers are included: \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
 \tcode{<list>}, \tcode{<map>}, \tcode{<regex>}, \tcode{<set>}, \tcode{<string>},
 \tcode{<unordered_map>}, \tcode{<unordered_set>}, and \tcode{<vector>}.
-}
 
-{\color{remclr}
 \indexlibrary{\idxcode{begin(C\&)}}%
 \begin{itemdecl}
 template <class C> auto begin(C& c) -> decltype(c.begin());
@@ -7623,9 +6750,9 @@ template <class C> auto crend(const C& c) -> decltype(std::rend(c));
 \begin{itemdescr}
 \pnum \returns \tcode{std::rend(c)}.
 \end{itemdescr}
-} %%\color{remclr}
+\end{removedblock}
 
-{\color{newclr}
+\begin{addedblock}
 \rSec2[iterator.range.begin]{\tcode{begin}}
 \pnum
 The name \tcode{begin} denotes a customization point
@@ -7862,55 +6989,27 @@ behaves similarly to \tcode{std::crend(E)} as defined in ISO/IEC 14882 when
 \enternote Whenever \tcode{ranges::crend(E)} is a valid expression, the
 types of \tcode{ranges::crend(E)} and \tcode{ranges::crbegin(E)} satisfy
 \tcode{Sentinel}. \exitnote
-} %%\color{newclr}
 
-{\color{newclr}
 \rSec1[range.primitives]{Range primitives}
-}
 
-{\color{oldclr}
-\indexlibrary{\idxcode{size}}%
-\begin{itemdecl}
-template <_Auto C> auto size(const C& c) -> decltype(c.size());
-\end{itemdecl}
-\begin{itemdescr}
-\pnum \returns \tcode{c.size()}.
-\end{itemdescr}
-
-\begin{itemdecl}
-template <_Auto T, size_t N> constexpr size_t size(T (&array)[N]) noexcept;
-\end{itemdecl}
-\begin{itemdescr}
-\pnum \returns \tcode{N}.
-\end{itemdescr}
-
-\begin{itemdecl}
-template <_Auto E> constexpr size_t size(initializer_list<E> il) noexcept;
-\end{itemdecl}
-\begin{itemdescr}
-\pnum \returns \tcode{il.size()}.
-\end{itemdescr}
-} %%\color{oldclr}
-
-{\color{newclr}
 \indexlibrary{\idxcode{distance(R\&\& r)}}%
 \begin{itemdecl}
-@\oldtxt{Range\{R\}}\newtxt{template <Range R>}@
-@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>> distance(R&& r);
+template <Range R>
+difference_type_t<iterator_t<R>> distance(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{ranges\oldtxt{_v1}::distance(\newtxt{ranges::}begin(r), \newtxt{ranges::}end(r))}
+\pnum \returns \tcode{ranges::distance(ranges::begin(r), ranges::end(r))}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{distance(R\&\& r)}}%
 \begin{itemdecl}
-@\oldtxt{SizedRange\{R\}}\newtxt{template <SizedRange R>}@
-@\oldtxt{DifferenceType}\newtxt{difference_type_t}@<@\oldtxt{IteratorType}\newtxt{iterator_t}@<R>> distance(R&& r);
+template <SizedRange R>
+difference_type_t<iterator_t<R>> distance(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{\newtxt{ranges::}size(r)}
+\pnum \returns \tcode{ranges::size(r)}
 \end{itemdescr}
 
 \rSec2[range.primitives.size]{\tcode{size}}
@@ -8028,4 +7127,4 @@ an rvalue. \exitnote
 \pnum
 \enternote Whenever \tcode{ranges::cdata(E)} is a valid expression, it
 has pointer to object type. \exitnote
-} %% color{newclr}
+\end{addedblock}


### PR DESCRIPTION
Fixes #173.

Don't merge this until after (1) merging Chris's markup cleanup of iterators.tex, and (2) correcting the resulting merge conflicts.