### PR TITLE
describes->specifies, more changes from ranges telecon 3

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -417,7 +417,7 @@ on values of possibly differing object types.
 \rSec2[concepts.lib.compare.boolean]{Concept Boolean}
 
 \pnum
-The \tcode{Boolean} concept describes the requirements on a type that is usable in Boolean contexts.
+The \tcode{Boolean} concept specifies the requirements on a type that is usable in Boolean contexts.
 
 \indexlibrary{\idxcode{Boolean}}%
 \begin{itemdecl}
@@ -632,10 +632,10 @@ Then  \tcode{StrictTotallyOrdered<T, U>()} is satisfied if and only if
 \rSec1[concepts.lib.object]{Object concepts}
 
 \pnum
-This section defines concepts that describe the basis of the
+This section describes concepts that specify the basis of the
 value-oriented programming style on which the library is based.
 \ednote{These concepts reuse many of the names of concepts that
-traditionally describe features of types to describe families of
+traditionally specify features of types to describe families of
 object types.}
 %% object types (See the rationale in Appendix~\ref{decomposition}).}
 
@@ -646,7 +646,7 @@ references to [destructible] with references to
 
 \pnum
 The \tcode{Destructible} concept is the base of the hierarchy of object concepts.
-It describes properties that all such object types have in common.
+It specifies properties that all such object types have in common.
 
 \indexlibrary{\idxcode{Destructible}}%
 \begin{itemdecl}

--- a/iterators.tex
+++ b/iterators.tex
@@ -336,7 +336,7 @@ like \tcode{shared_ptr<void>} is not \tcode{Readable} and has no associated valu
 \rSec2[iterators.writable]{Concept Writable}
 
 \pnum
-The \tcode{Writable} concept describes the requirements for writing a value into an iterator's
+The \tcode{Writable} concept specifies the requirements for writing a value into an iterator's
 referenced object.
 
 \indexlibrary{\idxcode{Writable}}%
@@ -382,8 +382,9 @@ The only valid use of an \tcode{operator*} is on the left side of the assignment
 \rSec2[iterators.weaklyincrementable]{Concept WeaklyIncrementable}
 
 \pnum
-The \tcode{WeaklyIncrementable} concept describes types that can be incremented with the pre-
-and post-increment operators. The increment operations are not required to be equality-preserving,
+The \tcode{WeaklyIncrementable} concept specifies the requirements on
+types that can be incremented with the pre- and post-increment operators.
+The increment operations are not required to be equality-preserving,
 nor is the type required to be \tcode{EqualityComparable}.
 
 \indexlibrary{\idxcode{WeaklyIncrementable}}%
@@ -426,7 +427,7 @@ template.\exitnote
 \rSec2[iterators.incrementable]{Concept Incrementable}
 
 \pnum
-The \tcode{Incrementable} concept describes types that can be incremented with the pre-
+The \tcode{Incrementable} concept specifies requirements on types that can be incremented with the pre-
 and post-increment operators. The increment operations are required to be equality-preserving,
 and the type is required to be \tcode{EqualityComparable}. \enternote This requirement
 supersedes the annotations on the increment expressions in the definition of
@@ -607,8 +608,9 @@ counted iterators and their sentinels~(\ref{counted.iterator}).\exitnote
 The \tcode{InputIterator} concept is a refinement of
 \tcode{Iterator}~(\ref{iterators.iterator}). It
 defines requirements for a type whose referenced values can be read (from the requirement for
-\tcode{Readable}~(\ref{iterators.readable})) and which can be both pre- and post-incremented. However,
-input iterators are not required to be comparable for equality.
+\tcode{Readable}~(\ref{iterators.readable})) and which can be both pre- and post-incremented.
+\enternote Unlike in ISO/IEC 14882, input iterators are not required to satisfy
+\tcode{EqualityComparable}~(\ref{concepts.lib.compare.equalitycomparable}).\exitnote
 
 \indexlibrary{\idxcode{InputIterator}}%
 \begin{codeblock}
@@ -695,7 +697,7 @@ are valid and have the indicated semantics, and
 \begin{addedblock}
 \pnum
 The \tcode{ForwardIterator} concept refines \tcode{InputIterator}~(\ref{iterators.input}),
-adding equality comparison and the multi-pass guarantee, described below.
+adding equality comparison and the multi-pass guarantee, specified below.
 
 \indexlibrary{\idxcode{ForwardIterator}}%
 \begin{codeblock}
@@ -1056,7 +1058,7 @@ requirements enabling the transfer to be performed through an intermediate objec
 \rSec2[commonalgoreq.indirectlyswappable]{Concept IndirectlySwappable}
 
 \pnum
-The \tcode{IndirectlySwappable} concept describes a swappable relationship between the
+The \tcode{IndirectlySwappable} concept specifies a swappable relationship between the
 reference types of two \tcode{Readable} types.
 
 \indexlibrary{\idxcode{IndirectlySwappable}}%


### PR DESCRIPTION
- The standard doesn't describe. It *specifies*.
- Replace "comparable for equality" with "satisfy EqualityComparable" in description (specification) of InputIterator.