### PR TITLE
Editorial: \tcode section headers where missing.

### DIFF
--- a/concepts.tex
+++ b/concepts.tex
@@ -146,7 +146,7 @@ This section contains the definition of concepts corresponding to language featu
 These concepts express relationships between types, type classifications, and
 fundamental type properties.
 
-\rSec2[concepts.lib.corelang.same]{Concept Same}
+\rSec2[concepts.lib.corelang.same]{Concept \tcode{Same}}
 
 \indexlibrary{\idxcode{Same}}%
 \begin{itemdecl}
@@ -166,7 +166,7 @@ only if \tcode{T} and \tcode{U} denote the same type.
 \tcode{Same<U, T>()}.
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.derived]{Concept DerivedFrom}
+\rSec2[concepts.lib.corelang.derived]{Concept \tcode{DerivedFrom}}
 
 \indexlibrary{\idxcode{DerivedFrom}}%
 \begin{itemdecl}
@@ -182,7 +182,7 @@ concept bool DerivedFrom() {
 \tcode{is_base_of<U, T>::value} is \tcode{true}.
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.convertibleto]{Concept ConvertibleTo}
+\rSec2[concepts.lib.corelang.convertibleto]{Concept \tcode{ConvertibleTo}}
 
 \indexlibrary{\idxcode{ConvertibleTo}}%
 \begin{itemdecl}
@@ -199,7 +199,7 @@ if and only if \tcode{is_convertible<T, U>::value} is \tcode{true}.
 \end{itemdescr}
 
 {\color{newclr}
-\rSec2[concepts.lib.corelang.commonref]{Concept CommonReference}
+\rSec2[concepts.lib.corelang.commonref]{Concept \tcode{CommonReference}}
 
 \pnum
 For two types \tcode{T} and \tcode{U}, if \tcode{common_reference_t<T, U>}
@@ -246,7 +246,7 @@ user-defined type. Those specializations are considered by the
 \end{itemdescr}
 } % \color{newclr}
 
-\rSec2[concepts.lib.corelang.common]{Concept Common}
+\rSec2[concepts.lib.corelang.common]{Concept \tcode{Common}}
 
 \pnum
 If \tcode{T} and \tcode{U} can both be explicitly converted to some third type,
@@ -293,7 +293,7 @@ user-defined type. Those specializations are considered by the \tcode{Common} co
 
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.integral]{Concept Integral}
+\rSec2[concepts.lib.corelang.integral]{Concept \tcode{Integral}}
 
 \indexlibrary{\idxcode{Integral}}%
 \begin{itemdecl}
@@ -303,7 +303,7 @@ concept bool Integral() {
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.corelang.signedintegral]{Concept SignedIntegral}
+\rSec2[concepts.lib.corelang.signedintegral]{Concept \tcode{SignedIntegral}}
 
 \indexlibrary{\idxcode{SignedIntegral}}%
 \begin{itemdecl}
@@ -321,7 +321,7 @@ for example, \tcode{char}.
 \exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.unsignedintegral]{Concept UnsignedIntegral}
+\rSec2[concepts.lib.corelang.unsignedintegral]{Concept \tcode{UnsignedIntegral}}
 
 \indexlibrary{\idxcode{UnsignedIntegral}}%
 \begin{itemdecl}
@@ -339,7 +339,7 @@ for example, \tcode{char}.
 \exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.assignable]{Concept Assignable}
+\rSec2[concepts.lib.corelang.assignable]{Concept \tcode{Assignable}}
 
 \indexlibrary{\idxcode{Assignable}}%
 \begin{itemdecl}
@@ -375,7 +375,7 @@ requirements must work as specified. \exitnote
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concepts.lib.corelang.swappable]{Concept Swappable}
+\rSec2[concepts.lib.corelang.swappable]{Concept \tcode{Swappable}}
 \ednote{Remove subclause [swappable.requirements]. Replace references to
 [swappable.requirements] with [concepts.lib.corelang.swappable].}
 
@@ -471,7 +471,7 @@ int main() {
 This section describes concepts that establish relationships and orderings
 on values of possibly differing object types.
 
-\rSec2[concepts.lib.compare.boolean]{Concept Boolean}
+\rSec2[concepts.lib.compare.boolean]{Concept \tcode{Boolean}}
 
 \pnum
 The \tcode{Boolean} concept specifies the requirements on a type that is usable in Boolean contexts.
@@ -526,7 +526,7 @@ Given values \tcode{b1} and \tcode{b2} of type \tcode{B}, then
 Pointers, smart pointers, and types with explicit conversions to \tcode{bool} are
 not \tcode{Boolean} types.\exitexample
 
-\rSec2[concepts.lib.compare.equalitycomparable]{Concept EqualityComparable}
+\rSec2[concepts.lib.compare.equalitycomparable]{Concept \tcode{EqualityComparable}}
 
 \ednote{Remove table [equalitycomparable] in [utility.arg.requirements]. Replace references to
 [equalitycomparable] with [concepts.lib.compare.equalitycomparable].}
@@ -605,7 +605,7 @@ is satisfied if and only if:
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concepts.lib.compare.stricttotallyordered]{Concept StrictTotallyOrdered}
+\rSec2[concepts.lib.compare.stricttotallyordered]{Concept \tcode{StrictTotallyOrdered}}
 
 \ednote{Remove table [lessthancomparable] in [utility.arg.requirements]. Replace uses of
 \tcode{LessThanComparable} with \tcode{StrictTotallyOrdered} (acknowledging that this is a breaking
@@ -694,7 +694,7 @@ traditionally specify features of types to describe families of
 object types.}
 %% object types (See the rationale in Appendix~\ref{decomposition}).}
 
-\rSec2[concepts.lib.object.destructible]{Concept Destructible}
+\rSec2[concepts.lib.object.destructible]{Concept \tcode{Destructible}}
 \ednote{Remove table [destructible] in [utility.arg.requirements]. Replace
 references to [destructible] with references to
 [concepts.lib.object.destructible].}
@@ -734,7 +734,7 @@ the denoted object(s) are reclaimed.
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concepts.lib.object.constructible]{Concept Constructible}
+\rSec2[concepts.lib.object.constructible]{Concept \tcode{Constructible}}
 
 \pnum
 The \tcode{Constructible} concept is used to constrain the type of a
@@ -763,7 +763,7 @@ concept bool Constructible() {
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.object.defaultconstructible]{Concept DefaultConstructible}
+\rSec2[concepts.lib.object.defaultconstructible]{Concept \tcode{DefaultConstructible}}
 
 \ednote{Remove table [defaultconstructible] in [utility.arg.requirements]. Replace
 references to [defaultconstructible] with references to
@@ -784,7 +784,7 @@ concept bool DefaultConstructible() {
 \enternote The array allocation expression \tcode{new T[n]\{\}} implicitly
 requires that \tcode{T} has a non-explicit default constructor. \exitnote
 
-\rSec2[concepts.lib.object.moveconstructible]{Concept MoveConstructible}
+\rSec2[concepts.lib.object.moveconstructible]{Concept \tcode{MoveConstructible}}
 \ednote{Remove table [moveconstructible] in [utility.arg.requirements]. Replace
 references to [moveconstructible] with references to
 [concepts.lib.object.moveconstructible].}
@@ -822,7 +822,7 @@ requirement \tcode{new T[1]\{std::move(t)\}}. This is not currently possible sin
 are initialized.}
 \end{itemdescr}
 
-\rSec2[concepts.lib.object.copyconstructible]{Concept CopyConstructible}
+\rSec2[concepts.lib.object.copyconstructible]{Concept \tcode{CopyConstructible}}
 \ednote{Remove table [copyconstructible] in [utility.arg.requirements]. Replace
 references to [copyconstructible] with references to
 [concepts.lib.object.copyconstructible].}
@@ -858,7 +858,7 @@ allocation requirement \tcode{new T[1]\{t\}}. This is not currently possible sin
 are initialized.}
 \end{itemdescr}
 
-\rSec2[concepts.lib.object.movable]{Concept Movable}
+\rSec2[concepts.lib.object.movable]{Concept \tcode{Movable}}
 \ednote{Remove table [moveassignable] in [utility.arg.requirements]. Replace
 references to [moveassignable] with references to
 [concepts.lib.object.movable].}
@@ -873,7 +873,7 @@ concept bool Movable() {
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.object.copyable]{Concept Copyable}
+\rSec2[concepts.lib.object.copyable]{Concept \tcode{Copyable}}
 \ednote{Remove table [copyassignable] in [utility.arg.requirements]. Replace
 references to [copyassignable] with references to
 [concepts.lib.object.copyable].}
@@ -888,7 +888,7 @@ concept bool Copyable() {
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.object.semiregular]{Concept Semiregular}
+\rSec2[concepts.lib.object.semiregular]{Concept \tcode{Semiregular}}
 
 \indexlibrary{\idxcode{Semiregular}}%
 \begin{itemdecl}
@@ -906,7 +906,7 @@ behave similarly to built-in types like \tcode{int}, except that they may not be
 comparable with \tcode{==}.\exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.object.regular]{Concept Regular}
+\rSec2[concepts.lib.object.regular]{Concept \tcode{Regular}}
 
 \indexlibrary{\idxcode{Regular}}%
 \begin{itemdecl}
@@ -931,7 +931,7 @@ similarly to built-in types like \tcode{int} and that are comparable with \tcode
 The concepts in this section describe the requirements on function
 objects~(\ref{function.objects}) and their arguments.
 
-\rSec2[concepts.lib.callables.callable]{Concept Callable}
+\rSec2[concepts.lib.callables.callable]{Concept \tcode{Callable}}
 
 \pnum
 The \tcode{Callable} concept specifies a relationship between a callable
@@ -957,7 +957,7 @@ equality-preserving~(\ref{concepts.lib.general.equality}), a function that gener
 may satisfy \tcode{Callable}.\exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.regularcallable]{Concept RegularCallable}
+\rSec2[concepts.lib.callables.regularcallable]{Concept \tcode{RegularCallable}}
 
 \indexlibrary{\idxcode{RegularCallable}}%
 \begin{itemdecl}
@@ -982,7 +982,7 @@ annotation in the definition of \tcode{Callable}. \exitnote
 \tcode{RegularCallable} is purely semantic.\exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.predicate]{Concept Predicate}
+\rSec2[concepts.lib.callables.predicate]{Concept \tcode{Predicate}}
 
 \indexlibrary{\idxcode{Predicate}}%
 \begin{itemdecl}
@@ -993,7 +993,7 @@ concept bool Predicate() {
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.callables.relation]{Concept Relation}
+\rSec2[concepts.lib.callables.relation]{Concept \tcode{Relation}}
 
 \indexlibrary{\idxcode{Relation}}%
 \begin{itemdecl}
@@ -1008,7 +1008,7 @@ concept bool Relation() {
     Relation<R, U>() &&
     Common@\newtxt{Reference}@<@\newtxt{const }@T@\newtxt{\&}@, @\newtxt{const }@U@\newtxt{\&}@>() &&
     Relation<R,
-      common_@\oldtxt{type}\newtxt{reference}@_t<@\newtxt{const }@T@\newtxt{\&}@, @\newtxt{const }@U@\newtxt{\&}@>>() &&    
+      common_@\oldtxt{type}\newtxt{reference}@_t<@\newtxt{const }@T@\newtxt{\&}@, @\newtxt{const }@U@\newtxt{\&}@>>() &&
     Predicate<R, T, U>() &&
     Predicate<R, U, T>();
 }
@@ -1028,7 +1028,7 @@ Then \tcode{Relation<R, T, U>()} is satisfied if and only if
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.strictweakorder]{Concept StrictWeakOrder}
+\rSec2[concepts.lib.callables.strictweakorder]{Concept \tcode{StrictWeakOrder}}
 
 \indexlibrary{\idxcode{Relation}}%
 \begin{itemdecl}

--- a/future.tex
+++ b/future.tex
@@ -7,25 +7,6 @@ A proper and full implementation has many more moving parts. In addition, we can
 this work presents to address long-standing shortcomings in the Standard Library. Some of these
 future work items are described below.
 
-\rSec1[future.proxy]{Proxy Iterators}
-
-\pnum
-As early at 1998 when Herb Sutter published his ``When is a Container not a Container''~\cite{Sutter1998}
-article, it was known that proxy iterators were a challenge that the current iterator concept
-hierarchy could not meet. The problem stems from the fact that the ForwardIterator concept as
-specified in the current standard requires the iterator's reference type to be a true reference, not
-a proxy. The Palo Alto report lifts this restriction in its respecification of the iterator
-concepts but doesn't actually solve the problem. The majority of algorithms, once you study the
-constraints, do not accept many interesting proxy iterator types.
-
-\pnum
-The author of this document has researched a possible library-only solution to the problem and
-implemented it in the range-v3 library. (The details of that solution are described in a series of
-blog posts beginning with ``To Be or Not to Be (an Iterator),'' Niebler, 2015~\cite{niebler2015}.) This
-document does not reflect the results of that research.
-
-Whether and how to best support proxy iterators is left as future work.
-
 \rSec1[future.iterator_range]{Iterator Range Type}
 
 \pnum
@@ -121,17 +102,6 @@ infinite range types: an infinite range that is delimited with a predicate or a 
 instance. The algorithm requirements should merely enforce that there is no integer overflow
 possible if the range happens to be larger than can be represented, not necessarily whether the
 algorithm will terminate or not.
-
-\rSec1[future.commontype]{Common Type}
-
-\pnum
-The all-important \tcode{Common} concept relies on the existence of a SFINAE-friendly
-\tcode{common_type} trait, which did not make it into \Cpp{}14. Solving the outstanding issues
-(active issues:
-\href{https://cplusplus.github.io/LWG/lwg-active.html#2460}{\#2460},
-\href{https://cplusplus.github.io/LWG/lwg-active.html#2465}{\#2465}; and defects:
-\href{https://cplusplus.github.io/LWG/lwg-defects.html#2408}{\#2408}) with \tcode{common_type} is
-left as future work on which the correctness of this document depends.
 
 \rSec1[future.numcont]{Numeric Algorithms and Containers}
 

--- a/iterators.tex
+++ b/iterators.tex
@@ -259,7 +259,7 @@ of \tcode{iterator_traits<X>}~(\cxxref{iterator.traits}). \exitnote
 }
 
 \begin{addedblock}
-\rSec2[iterators.readable]{Concept Readable}
+\rSec2[iterators.readable]{Concept \tcode{Readable}}
 
 \pnum
 The \tcode{Readable} concept is satisfied by types that are readable by
@@ -352,7 +352,7 @@ such that \tcode{I::element_type} is valid and denotes a type,
 \tcode{shared_ptr<int>} are \tcode{Readable} and have an associated value type. But a smart pointer
 like \tcode{shared_ptr<void>} is not \tcode{Readable} and has no associated value type.\exitnote
 
-\rSec2[iterators.writable]{Concept Writable}
+\rSec2[iterators.writable]{Concept \tcode{Writable}}
 
 \pnum
 The \tcode{Writable} concept specifies the requirements for writing a value into an iterator's
@@ -399,7 +399,7 @@ The only valid use of an \tcode{operator*} is on the left side of the assignment
 \textit{Assignment through the same value of the writable type happens only once.}
 \exitnote
 
-\rSec2[iterators.weaklyincrementable]{Concept WeaklyIncrementable}
+\rSec2[iterators.weaklyincrementable]{Concept \tcode{WeaklyIncrementable}}
 
 \pnum
 The \tcode{WeaklyIncrementable} concept specifies the requirements on
@@ -444,7 +444,7 @@ through the same incrementable value twice. They should be single pass algorithm
 can be used with istreams as the source of the input data through the \tcode{istream_iterator} class
 template.\exitnote
 
-\rSec2[iterators.incrementable]{Concept Incrementable}
+\rSec2[iterators.incrementable]{Concept \tcode{Incrementable}}
 
 \pnum
 The \tcode{Incrementable} concept specifies requirements on types that can be incremented with the pre-
@@ -487,7 +487,7 @@ algorithms with types that satisfy \tcode{Incrementable}.\exitnote
 
 \ednote{Section ``Iterator'' renamed to ``Concept Iterator'' below:}
 
-\rSec2[iterators.iterator]{Concept Iterator}
+\rSec2[iterators.iterator]{Concept \tcode{Iterator}}
 
 \pnum
 The \tcode{Iterator} \changed{requirements}{concept} form\added{s}
@@ -518,7 +518,7 @@ to provide a richer set of iterator movements~(\ref{iterators.forward},
 \enternote The requirement that the result of dereferencing the iterator is deducible from
 \tcode{auto\&\&} means that it cannot be \tcode{void}.\exitnote
 
-\rSec2[iterators.sentinel]{Concept Sentinel}
+\rSec2[iterators.sentinel]{Concept \tcode{Sentinel}}
 \pnum
 The \tcode{Sentinel} concept
 specifies the relationship
@@ -557,7 +557,7 @@ denotes a range and \tcode{i != s}, \range{i}{s} is not required to continue to
 denote a range after incrementing any iterator equal to \tcode{i}. Consequently,
 \tcode{i == s} is no longer required to be well-defined.
 
-\rSec2[iterators.sizedsentinel]{Concept SizedSentinel}
+\rSec2[iterators.sizedsentinel]{Concept \tcode{SizedSentinel}}
 \pnum
 The \tcode{SizedSentinel} concept specifies
 requirements on an \tcode{Iterator} and a \tcode{Sentinel}
@@ -619,7 +619,7 @@ counted iterators and their sentinels~(\ref{counted.iterator}).\exitnote
 
 \ednote{Section ``Input iterators'' renamed to ``Concept InputIterator'' below:}
 
-\rSec2[iterators.input]{Concept InputIterator}
+\rSec2[iterators.input]{Concept \tcode{InputIterator}}
 
 \ednote{Replace the entire content of the section with:}
 
@@ -651,7 +651,7 @@ defines requirements for a type whose referenced values can be read (from the re
 
 \ednote{Section ``Output iterators'' renamed to ``Concept OutputIterator'' below:}
 
-\rSec2[iterators.output]{Concept OutputIterator}
+\rSec2[iterators.output]{Concept \tcode{OutputIterator}}
 
 \ednote{Remove para 1 and Table 108}
 
@@ -690,7 +690,7 @@ for placing data through the
 class as well as with insert iterators and insert pointers.
 \exitnote
 
-\rSec2[iterators.forward]{Concept ForwardIterator}
+\rSec2[iterators.forward]{Concept \tcode{ForwardIterator}}
 
 \begin{removedblock}
 \pnum
@@ -772,7 +772,7 @@ or else neither is dereferenceable.}
 \removed{If \tcode{a} and \tcode{b} are both dereferenceable, then \tcode{a == b}
 if and only if \tcode{*a} and \tcode{*b} are bound to the same object.}
 
-\rSec2[iterators.bidirectional]{Concept BidirectionalIterator}
+\rSec2[iterators.bidirectional]{Concept \tcode{BidirectionalIterator}}
 
 \begin{removedblock}
 \pnum
@@ -831,7 +831,7 @@ Bidirectional iterators allow algorithms to move iterators backward as well as f
 \exitnote
 \end{removedblock}
 
-\rSec2[iterators.random.access]{Concept RandomAccessIterator}
+\rSec2[iterators.random.access]{Concept \tcode{RandomAccessIterator}}
 
 \begin{removedblock}
 \pnum
@@ -900,10 +900,6 @@ from \tcode{a}. Let \tcode{n} be the smallest value of type
 \pnum
 There are several concepts that group requirements of algorithms that take callable
 objects~(\cxxref{func.require}) as arguments.
-
-\ednote{Specifying the algorithms in terms of these indirect callable concepts would ease
-the transition should we ever decide to support proxy iterators in the future. See the
-Future Work appendix~(\ref{future.proxy}).}
 
 \rSec2[indirectcallables.indirectfunc]{Indirect callables}
 
@@ -1098,7 +1094,7 @@ concepts below impose additional constraints on their arguments beyond those tha
 concepts' bodies. \tcode{equal_to<>} requires its arguments satisfy \tcode{EqualityComparable}~(\ref{concepts.lib.compare.equalitycomparable}),
 and \tcode{less<>} requires its arguments satisfy \tcode{StrictTotallyOrdered}~(\ref{concepts.lib.compare.stricttotallyordered}).\exitnote
 
-\rSec2[commonalgoreq.indirectlymovable]{Concept IndirectlyMovable}
+\rSec2[commonalgoreq.indirectlymovable]{Concept \tcode{IndirectlyMovable}}
 
 \pnum
 The \tcode{IndirectlyMovable} concept specifies the relationship between a \tcode{Readable}
@@ -1134,7 +1130,7 @@ requirements enabling the transfer to be performed through an intermediate objec
   }
 \end{codeblock}
 
-\rSec2[commonalgoreq.indirectlycopyable]{Concept IndirectlyCopyable}
+\rSec2[commonalgoreq.indirectlycopyable]{Concept \tcode{IndirectlyCopyable}}
 
 \pnum
 The \tcode{IndirectlyCopyable} concept specifies the relationship between a \tcode{Readable}
@@ -1166,7 +1162,7 @@ requirements enabling the transfer to be performed through an intermediate objec
   }
 \end{codeblock}
 
-\rSec2[commonalgoreq.indirectlyswappable]{Concept IndirectlySwappable}
+\rSec2[commonalgoreq.indirectlyswappable]{Concept \tcode{IndirectlySwappable}}
 
 \pnum
 The \tcode{IndirectlySwappable} concept specifies a swappable relationship between the
@@ -1195,7 +1191,7 @@ type \tcode{I2}, \tcode{IndirectlySwappable<I1, I2>()} is satisfied if after
 value of \tcode{*i2} before the call, and \textit{vice versa}.
 } %\color{newclr}
 
-\rSec2[commonalgoreq.indirectlycomparable]{Concept IndirectlyComparable}
+\rSec2[commonalgoreq.indirectlycomparable]{Concept \tcode{IndirectlyComparable}}
 
 \pnum
 The \tcode{IndirectlyComparable} concept specifies the common requirements of algorithms that
@@ -1210,7 +1206,7 @@ compare values from two different sequences.
   }
 \end{codeblock}
 
-\rSec2[commonalgoreq.permutable]{Concept Permutable}
+\rSec2[commonalgoreq.permutable]{Concept \tcode{Permutable}}
 
 \pnum
 The \tcode{Permutable} concept specifies the common requirements of algorithms that reorder
@@ -1226,7 +1222,7 @@ elements in place by moving or swapping them.
   }
 \end{codeblock}
 
-\rSec2[commonalgoreq.mergeable]{Concept Mergeable}
+\rSec2[commonalgoreq.mergeable]{Concept \tcode{Mergeable}}
 
 \pnum
 The \tcode{Mergeable} concept specifies the requirements of
@@ -1246,7 +1242,7 @@ algorithms that merge sorted sequences into an output sequence by copying elemen
   }
 \end{codeblock}
 
-\rSec2[commonalgoreq.sortable]{Concept Sortable}
+\rSec2[commonalgoreq.sortable]{Concept \tcode{Sortable}}
 
 \pnum
 The \tcode{Sortable} concept specifies the common requirements of algorithms that permute
@@ -1753,7 +1749,7 @@ several classes and functions:
 {\color{newclr}
 \rSec2[iterator.utils]{Iterator utilities}
 
-\rSec3[iterator.utils.iter_move]{iter_move}
+\rSec3[iterator.utils.iter_move]{\tcode{iter_move}}
 
 \pnum
 The name \tcode{iter_move} denotes a \techterm{customization point
@@ -1799,7 +1795,7 @@ If, for the \tcode{iter_move} function selected by overload resolution,
 \tcode{iter_move(E)} does not equal \tcode{*E}, the program is ill-formed with
 no diagnostic required.
 
-\rSec3[iterator.utils.iter_swap]{iter_swap}
+\rSec3[iterator.utils.iter_swap]{\tcode{iter_swap}}
 
 \pnum
 The name \tcode{iter_swap} denotes a \techterm{customization point

--- a/utilities.tex
+++ b/utilities.tex
@@ -76,7 +76,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 \end{addedblock}
 
 \setcounter{subsection}{1}
-\rSec2[utility.swap]{swap}
+\rSec2[utility.swap]{\tcode{swap}}
 
 \begin{addedblock}
 \indexlibrary{\idxcode{swap}}%
@@ -200,7 +200,7 @@ for all \tcode{i} in the range \range{0}{N}.
 \end{itemdescr}
 \end{removedblock}
 
-\rSec2[utility.exchange]{exchange}
+\rSec2[utility.exchange]{\tcode{exchange}}
 
 \begin{itemdecl}
 template <@\changed{class}{MoveConstructible}@ T, class U=T>
@@ -303,7 +303,7 @@ as appropriate. (Renumbering hasn't been performed herein to ease review.)}
 
 \begin{addedblock}
 \setcounter{subsection}{2}
-\rSec2[func.invoke]{Function template invoke}
+\rSec2[func.invoke]{Function template \tcode{invoke}}
 \begin{itemdecl}
 template <class F, class... Args>
 result_of_t<F&&(Args&&...)> invoke(F&& f, Args&&... args);
@@ -535,7 +535,7 @@ do not.
 
 \setcounter{subsection}{12}
 \begin{addedblock}
-\rSec2[func.identity]{Class identity}
+\rSec2[func.identity]{Class \tcode{identity}}
 
 \indexlibrary{\idxcode{identity}}%
 \begin{itemdecl}
@@ -570,17 +570,17 @@ namespace std {
   // 20.10.4.3, type properties:
   [@...@]
   template <class T> struct is_move_assignable;
-  
+
   @\newtxt{template <class T, class U> struct is_swappable_with;}@
   @\newtxt{template <class T> struct is_swappable;}@
-  
+
   template <class T> struct is_destructible;
   [@...@]
   template <class T> struct is_nothrow_move_assignable;
 
   @\newtxt{template <class T, class U> struct is_nothrow_swappable_with;}@
   @\newtxt{template <class T> struct is_nothrow_swappable;}@
-  
+
   template <class T> struct is_nothrow_destructible;
   [@...@]
 
@@ -748,23 +748,23 @@ handle proxy reference types in generic code.} \end{note} \\ \rowsep
 
 {\color{newclr}
 \pnum
-Let \tcode{CREF(A)} be \tcode{add_lvalue_reference_t<const 
+Let \tcode{CREF(A)} be \tcode{add_lvalue_reference_t<const
 remove_reference_t<A>{}>}. Let \tcode{UNCVREF(A)} be
-\tcode{remove_cv_t<remove_reference_t<A>{}>}. Let \tcode{XREF(A)} 
-denote a unary template \tcode{T} such that \tcode{T<UNCVREF(A)>} 
-denotes the same type as \tcode{A}. Let \tcode{COPYCV(FROM, TO)} be 
-an alias for type \tcode{TO} with the addition of \tcode{FROM}'s 
-top-level \cv-qualifiers. \enterexample \tcode{COPYCV(const int, 
-volatile short)} is an alias for \tcode{const volatile short}. 
+\tcode{remove_cv_t<remove_reference_t<A>{}>}. Let \tcode{XREF(A)}
+denote a unary template \tcode{T} such that \tcode{T<UNCVREF(A)>}
+denotes the same type as \tcode{A}. Let \tcode{COPYCV(FROM, TO)} be
+an alias for type \tcode{TO} with the addition of \tcode{FROM}'s
+top-level \cv-qualifiers. \enterexample \tcode{COPYCV(const int,
+volatile short)} is an alias for \tcode{const volatile short}.
 \exitexample Let \tcode{RREF_RES(Z)} be
-\tcode{remove_reference_t<Z>\&\&} if \tcode{Z} is a reference type 
+\tcode{remove_reference_t<Z>\&\&} if \tcode{Z} is a reference type
 or \tcode{Z} otherwise. Let \tcode{COND_RES(X, Y)} be
-\tcode{decltype(declval<bool>() ? declval<X>() : declval<Y>())}. 
+\tcode{decltype(declval<bool>() ? declval<X>() : declval<Y>())}.
 Given types \tcode{A} and \tcode{B}, let \tcode{X} be
 \tcode{remove_reference_t<A>}, let \tcode{Y} be
 \tcode{remove_reference_t<B>}, and let \tcode{COMMON_REF(A, B)} be:
 \begin{itemize}
-\item If \tcode{A} and \tcode{B} are both lvalue reference types, 
+\item If \tcode{A} and \tcode{B} are both lvalue reference types,
   \tcode{COMMON_REF(A, B)} is
   \tcode{COND_RES(COPYCV(X, Y) \&, COPYCV(Y, X) \&)}.
 \item Otherwise, let \tcode{C} be
@@ -774,8 +774,8 @@ Given types \tcode{A} and \tcode{B}, let \tcode{X} be
   \tcode{is_convertible<B, C>::value} are \tcode{true}, then
   \tcode{COMMON_REF(A, B)} is \tcode{C}.
 \item Otherwise, let \tcode{D} be
-  \tcode{COMMON_REF(const X\&, Y\&)}. If \tcode{A} is an rvalue 
-  reference and \tcode{B} is an lvalue reference and \tcode{D} is 
+  \tcode{COMMON_REF(const X\&, Y\&)}. If \tcode{A} is an rvalue
+  reference and \tcode{B} is an lvalue reference and \tcode{D} is
   well-formed and \tcode{is_convertible<A, D>::value} is
   \tcode{true}, then \tcode{COMMON_REF(A, B)} is \tcode{D}.
 \item Otherwise, if \tcode{A} is an lvalue reference and \tcode{B}


### PR DESCRIPTION
Remove reference to proxy iterators and common_type future work which is now integrated.