### PR TITLE
Rename Callable concepts to Invocable concepts, fixes #254

### DIFF
--- a/algorithms.tex
+++ b/algorithms.tex
@@ -47,82 +47,82 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.nonmodifying}, non-modifying sequence operations:
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     bool all_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool all_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     bool any_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool any_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     bool none_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallable<projected<I, Proj>> Fun>
+      IndirectInvocable<projected<I, Proj>> Fun>
     tagged_pair<tag::in(I), tag::fun(Fun)>
       for_each(I first, S last, Fun f, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallable<projected<iterator_t<Rng>, Proj>> Fun>
+      IndirectInvocable<projected<iterator_t<Rng>, Proj>> Fun>
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::fun(Fun)>
       for_each(Rng&& rng, Fun f, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-    requires IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
     I find(I first, S last, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, class T, class Proj = identity>
-    requires IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     safe_iterator_t<Rng>
       find(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     I find_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       find_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     I find_if_not(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
       Sentinel<I2> S2, class Proj = identity,
-      IndirectCallableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
+      IndirectInvocableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
     I1
       find_end(I1 first1, S1 last1, I2 first2, S2 last2,
                Pred pred = Pred{}, Proj proj = Proj{});
 
   template <ForwardRange Rng1, ForwardRange Rng2, class Proj = identity,
-      IndirectCallableRelation<iterator_t<Rng2>,
+      IndirectInvocableRelation<iterator_t<Rng2>,
         projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
     safe_iterator_t<Rng1>
       find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{});
 
   template <InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     I1
       find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
                     Pred pred = Pred{},
@@ -130,7 +130,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputRange Rng1, ForwardRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
     safe_iterator_t<Rng1>
       find_first_of(Rng1&& rng1, Rng2&& rng2,
@@ -138,40 +138,40 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
                     Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableRelation<projected<I, Proj>> Pred = equal_to<>>
+      IndirectInvocableRelation<projected<I, Proj>> Pred = equal_to<>>
     I
       adjacent_find(I first, S last, Pred pred = Pred{},
                     Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
+      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
     safe_iterator_t<Rng>
       adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-    requires IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
     difference_type_t<I>
       count(I first, S last, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, class T, class Proj = identity>
-    requires IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     difference_type_t<iterator_t<Rng>>
       count(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     difference_type_t<I>
       count_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     difference_type_t<iterator_t<Rng>>
       count_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   // \ref{depr.algo.range-and-a-half} (deprecated):
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(I1), tag::in2(I2)>
       mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -179,7 +179,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   // \ref{depr.algo.range-and-a-half} (deprecated):
   template <InputRange Rng1, InputIterator I2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
       mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -187,14 +187,14 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(I1), tag::in2(I2)>
       mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(safe_iterator_t<Rng1>),
                 tag::in2(safe_iterator_t<Rng2>)>
@@ -307,13 +307,13 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       copy_n(I first, difference_type_t<I> n, O result);
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -420,24 +420,24 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <ForwardIterator I, Sentinel<I> S, class T1, class T2, class Proj = identity>
     requires Writable<I, const T2&>() &&
-      IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
     I
       replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T1, class T2, class Proj = identity>
     requires Writable<iterator_t<Rng>, const T2&>() &&
-      IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
     safe_iterator_t<Rng>
       replace(Rng&& rng, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires Writable<I, const T&>()
     I
       replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Writable<iterator_t<Rng>, const T&>()
     safe_iterator_t<Rng>
       replace_if(Rng&& rng, Pred pred, const T& new_value, Proj proj = Proj{});
@@ -445,7 +445,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<const T2&> O,
       class Proj = identity>
     requires IndirectlyCopyable<I, O>() &&
-      IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
     tagged_pair<tag::in(I), tag::out(O)>
       replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                    Proj proj = Proj{});
@@ -453,20 +453,20 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputRange Rng, class T1, class T2, OutputIterator<const T2&> O,
       class Proj = identity>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-      IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       replace_copy(Rng&& rng, O result, const T1& old_value, const T2& new_value,
                    Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, OutputIterator<const T&> O,
-      class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                       Proj proj = Proj{});
 
   template <InputRange Rng, class T, OutputIterator<const T&> O, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       replace_copy_if(Rng&& rng, O result, Pred pred, const T& new_value,
@@ -482,35 +482,35 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <class T, OutputIterator<const T&> O>
     O fill_n(O first, difference_type_t<O> n, const T& value);
 
-  template <Callable F, OutputIterator<result_of_t<F&()>> O,
+  template <Invocable F, OutputIterator<result_of_t<F&()>> O,
       Sentinel<O> S>
     O generate(O first, S last, F gen);
 
-  template <Callable F, OutputRange<result_of_t<F&()>> Rng>
+  template <Invocable F, OutputRange<result_of_t<F&()>> Rng>
     safe_iterator_t<Rng>
       generate(Rng&& rng, F gen);
 
-  template <Callable F, OutputIterator<result_of_t<F&()>> O>
+  template <Invocable F, OutputIterator<result_of_t<F&()>> O>
     O generate_n(O first, difference_type_t<O> n, F gen);
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
     requires Permutable<I>() &&
-      IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
     I remove(I first, S last, const T& value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity>
     requires Permutable<iterator_t<Rng>>() &&
-      IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     safe_iterator_t<Rng>
       remove(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I remove_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       remove_if(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -518,48 +518,48 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
       class Proj = identity>
     requires IndirectlyCopyable<I, O>() &&
-      IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
     tagged_pair<tag::in(I), tag::out(O)>
       remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class T, class Proj = identity>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-      IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       remove_copy(Rng&& rng, O result, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-      class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       remove_copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableRelation<projected<I, Proj>> R = equal_to<>>
+      IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
     requires Permutable<I>()
     I unique(I first, S last, R comp = R{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       unique(Rng&& rng, R comp = R{}, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-      class Proj = identity, IndirectCallableRelation<projected<I, Proj>> R = equal_to<>>
+      class Proj = identity, IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
     requires IndirectlyCopyable<I, O>() && (ForwardIterator<I>() ||
       ForwardIterator<O>() || IndirectlyCopyableStorable<I, O>())
     tagged_pair<tag::in(I), tag::out(O)>
       unique_copy(I first, S last, O result, R comp = R{}, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
       (ForwardIterator<iterator_t<Rng>>() || ForwardIterator<O>() ||
        IndirectlyCopyableStorable<iterator_t<Rng>, O>())
@@ -621,38 +621,38 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.partitions}, partitions:
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     bool is_partitioned(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool
       is_partitioned(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I partition(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       partition(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I stable_partition(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <BidirectionalRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncrementable O2,
-      class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O1>() && IndirectlyCopyable<I, O2>()
     tagged_tuple<tag::in(I), tag::out1(O1), tag::out2(O2)>
       partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
@@ -660,18 +660,18 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputRange Rng, WeaklyIncrementable O1, WeaklyIncrementable O2,
       class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O1>() &&
       IndirectlyCopyable<iterator_t<Rng>, O2>()
     tagged_tuple<tag::in(safe_iterator_t<Rng>), tag::out1(O1), tag::out2(O2)>
       partition_copy(Rng&& rng, O1 out_true, O2 out_false, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallablePredicate<projected<I, Proj>> Pred>
+      IndirectInvocablePredicate<projected<I, Proj>> Pred>
     I partition_point(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       partition_point(Rng&& rng, Pred pred, Proj proj = Proj{});
 
@@ -711,7 +711,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2> S2,
       class Comp = less<>, class Proj1 = identity, class Proj2 = identity>
     requires IndirectlyCopyable<I1, I2>() && Sortable<I2, Comp, Proj2>() &&
-        IndirectCallableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
+        IndirectInvocableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
     I2
       partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                         Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -720,27 +720,27 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       class Proj1 = identity, class Proj2 = identity>
     requires IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>() &&
         Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
-        IndirectCallableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
+        IndirectInvocableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
           projected<iterator_t<Rng2>, Proj2>>()
     safe_iterator_t<Rng2>
       partial_sort_copy(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
                         Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     bool is_sorted(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       is_sorted(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I is_sorted_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       is_sorted_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
@@ -756,45 +756,45 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.binary.search}, binary search:
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     I
       lower_bound(I first, S last, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     I
       upper_bound(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       upper_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     tagged_pair<tag::begin(I), tag::end(I)>
       equal_range(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     tagged_pair<tag::begin(safe_iterator_t<Rng>),
                 tag::end(safe_iterator_t<Rng>)>
       equal_range(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     bool
       binary_search(I first, S last, const T& value, Comp comp = Comp{},
                     Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       binary_search(Rng&& rng, const T& value, Comp comp = Comp{},
                     Proj proj = Proj{});
@@ -832,14 +832,14 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   // \ref{alg.set.operations}, set operations:
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
     bool
       includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
     bool
       includes(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -948,108 +948,108 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       sort_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     bool is_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       is_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I is_heap_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       is_heap_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   // \ref{alg.min.max}, minimum and maximum:
   template <class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr const T& min(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr T min(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     value_type_t<iterator_t<Rng>>
       min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr const T& max(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr T max(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     value_type_t<iterator_t<Rng>>
       max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <class T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
       minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr tagged_pair<tag::min(T), tag::max(T)>
       minmax(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
                 tag::max(value_type_t<iterator_t<Rng>>)>
       minmax(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I min_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       min_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I max_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       max_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     tagged_pair<tag::min(I), tag::max(I)>
       minmax_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     tagged_pair<tag::min(safe_iterator_t<Rng>),
                 tag::max(safe_iterator_t<Rng>)>
       minmax_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectCallableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+      IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
     bool
       lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                               Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectCallableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
     bool
       lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -1221,11 +1221,11 @@ struct @\xname{input_getter}@ {
 \indexlibrary{\idxcode{all_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   bool all_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool all_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1247,11 +1247,11 @@ and \tcode{last - first} applications of the projection.
 \indexlibrary{\idxcode{any_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   bool any_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool any_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1273,11 +1273,11 @@ and \tcode{last - first} applications of the projection.
 \indexlibrary{\idxcode{none_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   bool none_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1299,12 +1299,12 @@ and \tcode{last - first} applications of the projection.
 \indexlibrary{\idxcode{for_each}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallable<projected<I, Proj>> Fun>
+    IndirectInvocable<projected<I, Proj>> Fun>
   tagged_pair<tag::in(I), tag::fun(Fun)>
     for_each(I first, S last, Fun f, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallable<projected<iterator_t<Rng>, Proj>> Fun>
+    IndirectInvocable<projected<iterator_t<Rng>, Proj>> Fun>
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::fun(Fun)>
     for_each(Rng&& rng, Fun f, Proj proj = Proj{});
 \end{itemdecl}
@@ -1347,29 +1347,29 @@ If \tcode{f} returns a result, the result is ignored.
 \indexlibrary{\idxcode{find_if_not}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-  requires IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+  requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
   I find(I first, S last, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, class T, class Proj = identity>
-  requires IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+  requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   safe_iterator_t<Rng>
     find(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   I find_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     find_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   I find_if_not(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -1401,14 +1401,14 @@ applications of the corresponding predicate and projection.
 \begin{itemdecl}
 template <ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
     Sentinel<I2> S2, class Proj = identity,
-    IndirectCallableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
+    IndirectInvocableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
   I1
     find_end(I1 first1, S1 last1, I2 first2, S2 last2,
              Pred pred = Pred{}, Proj proj = Proj{});
 
 template <ForwardRange Rng1, ForwardRange Rng2,
     class Proj = identity,
-    IndirectCallableRelation<iterator_t<Rng2>,
+    IndirectInvocableRelation<iterator_t<Rng2>,
       projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
   safe_iterator_t<Rng1>
     find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{});
@@ -1446,14 +1446,14 @@ applications of the corresponding predicate and projection.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   I1
     find_first_of(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
                   Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, ForwardRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
   safe_iterator_t<Rng1>
     find_first_of(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
@@ -1492,13 +1492,13 @@ applications of the corresponding predicate and the two projections.
 \indexlibrary{\idxcode{adjacent_find}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableRelation<projected<I, Proj>> Pred = equal_to<>>
+    IndirectInvocableRelation<projected<I, Proj>> Pred = equal_to<>>
   I
     adjacent_find(I first, S last, Pred pred = Pred{},
                   Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
+    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
   safe_iterator_t<Rng>
     adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -1536,22 +1536,22 @@ return value, and no more than twice as many applications of the projection.
 \indexlibrary{\idxcode{count_if}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-  requires IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+  requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
   difference_type_t<I>
     count(I first, S last, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, class T, class Proj = identity>
-  requires IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+  requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   difference_type_t<iterator_t<Rng>>
     count(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   difference_type_t<I>
     count_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   difference_type_t<iterator_t<Rng>>
     count_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -1580,7 +1580,7 @@ applications of the corresponding predicate and projection.
 // \ref{depr.algo.range-and-a-half} (deprecated):
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -1588,7 +1588,7 @@ template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
 // \ref{depr.algo.range-and-a-half} (deprecated):
 template <InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
     mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -1596,14 +1596,14 @@ template <InputRange Rng1, InputIterator I2,
 
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>)>
     mismatch(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
@@ -1926,13 +1926,13 @@ $i < n$, performs \tcode{*(result + i) = *(first + i)}.
 \indexlibrary{\idxcode{copy_n}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -2260,24 +2260,24 @@ in case of binary transform.
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T1, class T2, class Proj = identity>
   requires Writable<I, const T2&>() &&
-    IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
   I
     replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T1, class T2, class Proj = identity>
   requires Writable<iterator_t<Rng>, const T2&>() &&
-    IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
   safe_iterator_t<Rng>
     replace(Rng&& rng, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires Writable<I, const T&>()
   I
     replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Writable<iterator_t<Rng>, const T&>()
   safe_iterator_t<Rng>
     replace_if(Rng&& rng, Pred pred, const T& new_value, Proj proj = Proj{});
@@ -2311,7 +2311,7 @@ applications of the corresponding predicate and projection.
 template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<const T2&> O,
     class Proj = identity>
   requires IndirectlyCopyable<I, O>() &&
-    IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
   tagged_pair<tag::in(I), tag::out(O)>
     replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                  Proj proj = Proj{});
@@ -2319,20 +2319,20 @@ template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<con
 template <InputRange Rng, class T1, class T2, OutputIterator<const T2&> O,
     class Proj = identity>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-    IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     replace_copy(Rng&& rng, O result, const T1& old_value, const T2& new_value,
                  Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class T, OutputIterator<const T&> O,
-    class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                     Proj proj = Proj{});
 
 template <InputRange Rng, class T, OutputIterator<const T&> O, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     replace_copy_if(Rng&& rng, O result, Pred pred, const T& new_value,
@@ -2417,15 +2417,15 @@ Exactly
 \indexlibrary{\idxcode{generate}}%
 \indexlibrary{\idxcode{generate_n}}%
 \begin{itemdecl}
-template <Callable F, OutputIterator<result_of_t<F&()>> O,
+template <Invocable F, OutputIterator<result_of_t<F&()>> O,
     Sentinel<O> S>
   O generate(O first, S last, F gen);
 
-template <Callable F, OutputRange<result_of_t<F&()>> Rng>
+template <Invocable F, OutputRange<result_of_t<F&()>> Rng>
   safe_iterator_t<Rng>
     generate(Rng&& rng, F gen);
 
-template <Callable F, OutputIterator<result_of_t<F&()>> O>
+template <Invocable F, OutputIterator<result_of_t<F&()>> O>
   O generate_n(O first, difference_type_t<O> n, F gen);
 \end{itemdecl}
 
@@ -2453,22 +2453,22 @@ Exactly
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
   requires Permutable<I>() &&
-    IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
   I remove(I first, S last, const T& value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity>
   requires Permutable<iterator_t<Rng>>() &&
-    IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   safe_iterator_t<Rng>
     remove(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I remove_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     remove_if(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2510,24 +2510,24 @@ in that range.
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
     class Proj = identity>
   requires IndirectlyCopyable<I, O>() &&
-    IndirectCallableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
   tagged_pair<tag::in(I), tag::out(O)>
     remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class T, class Proj = identity>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-    IndirectCallableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     remove_copy(Rng&& rng, O result, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-    class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     remove_copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -2571,12 +2571,12 @@ applications of the corresponding predicate and projection.
 \indexlibrary{\idxcode{unique}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableRelation<projected<I, Proj>> R = equal_to<>>
+    IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
   requires Permutable<I>()
   I unique(I first, S last, R comp = R{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     unique(Rng&& rng, R comp = R{}, Proj proj = Proj{});
@@ -2610,14 +2610,14 @@ applications of the projection.
 \indexlibrary{\idxcode{unique_copy}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-    class Proj = identity, IndirectCallableRelation<projected<I, Proj>> R = equal_to<>>
+    class Proj = identity, IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
   requires IndirectlyCopyable<I, O>() && (ForwardIterator<I>() ||
     ForwardIterator<O>() || IndirectlyCopyableStorable<I, O>())
   tagged_pair<tag::in(I), tag::out(O)>
     unique_copy(I first, S last, O result, R comp = R{}, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectCallableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
     (ForwardIterator<iterator_t<Rng>>() || ForwardIterator<O>() ||
      IndirectlyCopyableStorable<iterator_t<Rng>, O>())
@@ -2873,11 +2873,11 @@ randomness.
 \indexlibrary{\idxcode{is_partitioned}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   bool is_partitioned(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool
     is_partitioned(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -2898,12 +2898,12 @@ for every \tcode{i} in \range{first}{last}.
 \indexlibrary{\idxcode{partition}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I partition(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     partition(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2931,12 +2931,12 @@ Exactly \tcode{last - first} applications of the predicate and projection.
 \indexlibrary{\idxcode{stable_partition}}%
 \begin{itemdecl}
 template <BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I stable_partition(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <BidirectionalRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2978,7 +2978,7 @@ applications of the predicate and projection.
 \indexlibrary{\idxcode{partition_copy}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncrementable O2,
-    class Proj = identity, IndirectCallablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O1>() && IndirectlyCopyable<I, O2>()
   tagged_tuple<tag::in(I), tag::out1(O1), tag::out2(O2)>
     partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
@@ -2986,7 +2986,7 @@ template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncremen
 
 template <InputRange Rng, WeaklyIncrementable O1, WeaklyIncrementable O2,
     class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O1>() &&
     IndirectlyCopyable<iterator_t<Rng>, O2>()
   tagged_tuple<tag::in(safe_iterator_t<Rng>), tag::out1(O1), tag::out2(O2)>
@@ -3016,11 +3016,11 @@ and \tcode{get<2>(p)} is the end of the output range beginning at \tcode{out_fal
 \indexlibrary{\idxcode{partition_point}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallablePredicate<projected<I, Proj>> Pred>
+    IndirectInvocablePredicate<projected<I, Proj>> Pred>
   I partition_point(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     partition_point(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -3207,7 +3207,7 @@ comparisons.
 template <InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2> S2,
     class Comp = less<>, class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyCopyable<I1, I2>() && Sortable<I2, Comp, Proj2>() &&
-      IndirectCallableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
+      IndirectInvocableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
   I2
     partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                       Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -3216,7 +3216,7 @@ template <InputRange Rng1, RandomAccessRange Rng2, class Comp = less<>,
     class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>() &&
       Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
-      IndirectCallableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
+      IndirectInvocableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>>()
   safe_iterator_t<Rng2>
     partial_sort_copy(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
@@ -3249,11 +3249,11 @@ comparisons.
 \indexlibrary{\idxcode{is_sorted}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   bool is_sorted(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     is_sorted(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3266,11 +3266,11 @@ template <ForwardRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{is_sorted_until}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I is_sorted_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     is_sorted_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3343,13 +3343,13 @@ For non-random access iterators they execute a linear number of steps.
 \indexlibrary{\idxcode{lower_bound}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   I
     lower_bound(I first, S last, const T& value, Comp comp = Comp{},
                 Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3389,12 +3389,12 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{upper_bound}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   I
     upper_bound(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     upper_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3434,12 +3434,12 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{equal_range}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   tagged_pair<tag::begin(I), tag::end(I)>
     equal_range(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   tagged_pair<tag::begin(safe_iterator_t<Rng>),
               tag::end(safe_iterator_t<Rng>)>
     equal_range(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
@@ -3483,13 +3483,13 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{binary_search}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   bool
     binary_search(I first, S last, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     binary_search(Rng&& rng, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
@@ -3667,14 +3667,14 @@ to contain the minimum, and so on.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
   bool
     includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = Comp{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
   bool
     includes(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -4100,11 +4100,11 @@ comparisons (where
 \indexlibrary{\idxcode{is_heap}}%
 \begin{itemdecl}
 template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   bool is_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <RandomAccessRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     is_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4117,11 +4117,11 @@ template <RandomAccessRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{is_heap_until}}%
 \begin{itemdecl}
 template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I is_heap_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <RandomAccessRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     is_heap_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4142,7 +4142,7 @@ range \range{first}{i} is a heap.
 \indexlibrary{\idxcode{min}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr const T& min(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -4159,11 +4159,11 @@ Returns the first argument when the arguments are equivalent.
 \indexlibrary{\idxcode{min}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr T min(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   value_type_t<iterator_t<Rng>>
     min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4183,7 +4183,7 @@ template <InputRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{max}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr const T& max(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -4200,11 +4200,11 @@ Returns the first argument when the arguments are equivalent.
 \indexlibrary{\idxcode{max}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr T max(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   value_type_t<iterator_t<Rng>>
     max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4224,7 +4224,7 @@ template <InputRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{minmax}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
     minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4248,12 +4248,12 @@ Exactly one comparison and exactly two applications of the projection.
 \indexlibrary{\idxcode{minmax}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr tagged_pair<tag::min(T), tag::max(T)>
     minmax(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
               tag::max(value_type_t<iterator_t<Rng>>)>
@@ -4281,11 +4281,11 @@ applications of the corresponding predicate, and at most twice as many applicati
 \indexlibrary{\idxcode{min_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I min_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     min_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4319,11 +4319,11 @@ exactly twice as many applications of the projection.
 \indexlibrary{\idxcode{max_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I max_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     max_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4357,12 +4357,12 @@ exactly twice as many applications of the projection.
 \indexlibrary{\idxcode{minmax_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   tagged_pair<tag::min(I), tag::max(I)>
     minmax_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   tagged_pair<tag::min(safe_iterator_t<Rng>),
               tag::max(safe_iterator_t<Rng>)>
     minmax_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4392,14 +4392,14 @@ where $N$ is \tcode{distance(first, last)}.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+    IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
   bool
     lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                             Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectCallableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
   bool
     lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},

--- a/algorithms.tex
+++ b/algorithms.tex
@@ -47,27 +47,27 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.nonmodifying}, non-modifying sequence operations:
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     bool all_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool all_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     bool any_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool any_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     bool none_of(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
@@ -81,48 +81,48 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       for_each(Rng&& rng, Fun f, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-    requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
     I find(I first, S last, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, class T, class Proj = identity>
-    requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    requires IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     safe_iterator_t<Rng>
       find(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     I find_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       find_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     I find_if_not(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
       Sentinel<I2> S2, class Proj = identity,
-      IndirectInvocableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
+      IndirectRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
     I1
       find_end(I1 first1, S1 last1, I2 first2, S2 last2,
                Pred pred = Pred{}, Proj proj = Proj{});
 
   template <ForwardRange Rng1, ForwardRange Rng2, class Proj = identity,
-      IndirectInvocableRelation<iterator_t<Rng2>,
+      IndirectRelation<iterator_t<Rng2>,
         projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
     safe_iterator_t<Rng1>
       find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{});
 
   template <InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     I1
       find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
                     Pred pred = Pred{},
@@ -130,7 +130,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputRange Rng1, ForwardRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
     safe_iterator_t<Rng1>
       find_first_of(Rng1&& rng1, Rng2&& rng2,
@@ -138,40 +138,40 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
                     Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableRelation<projected<I, Proj>> Pred = equal_to<>>
+      IndirectRelation<projected<I, Proj>> Pred = equal_to<>>
     I
       adjacent_find(I first, S last, Pred pred = Pred{},
                     Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
+      IndirectRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
     safe_iterator_t<Rng>
       adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-    requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
     difference_type_t<I>
       count(I first, S last, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, class T, class Proj = identity>
-    requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    requires IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     difference_type_t<iterator_t<Rng>>
       count(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     difference_type_t<I>
       count_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     difference_type_t<iterator_t<Rng>>
       count_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   // \ref{depr.algo.range-and-a-half} (deprecated):
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(I1), tag::in2(I2)>
       mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -179,7 +179,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   // \ref{depr.algo.range-and-a-half} (deprecated):
   template <InputRange Rng1, InputIterator I2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
       mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -187,14 +187,14 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+      IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(I1), tag::in2(I2)>
       mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+      IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
     tagged_pair<tag::in1(safe_iterator_t<Rng1>),
                 tag::in2(safe_iterator_t<Rng2>)>
@@ -307,13 +307,13 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       copy_n(I first, difference_type_t<I> n, O result);
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -420,24 +420,24 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <ForwardIterator I, Sentinel<I> S, class T1, class T2, class Proj = identity>
     requires Writable<I, const T2&>() &&
-      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+      IndirectRelation<equal_to<>, projected<I, Proj>, const T1*>()
     I
       replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T1, class T2, class Proj = identity>
     requires Writable<iterator_t<Rng>, const T2&>() &&
-      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+      IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
     safe_iterator_t<Rng>
       replace(Rng&& rng, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     requires Writable<I, const T&>()
     I
       replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Writable<iterator_t<Rng>, const T&>()
     safe_iterator_t<Rng>
       replace_if(Rng&& rng, Pred pred, const T& new_value, Proj proj = Proj{});
@@ -445,7 +445,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<const T2&> O,
       class Proj = identity>
     requires IndirectlyCopyable<I, O>() &&
-      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+      IndirectRelation<equal_to<>, projected<I, Proj>, const T1*>()
     tagged_pair<tag::in(I), tag::out(O)>
       replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                    Proj proj = Proj{});
@@ -453,20 +453,20 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputRange Rng, class T1, class T2, OutputIterator<const T2&> O,
       class Proj = identity>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+      IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       replace_copy(Rng&& rng, O result, const T1& old_value, const T2& new_value,
                    Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, class T, OutputIterator<const T&> O,
-      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                       Proj proj = Proj{});
 
   template <InputRange Rng, class T, OutputIterator<const T&> O, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       replace_copy_if(Rng&& rng, O result, Pred pred, const T& new_value,
@@ -495,22 +495,22 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
     requires Permutable<I>() &&
-      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+      IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
     I remove(I first, S last, const T& value, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity>
     requires Permutable<iterator_t<Rng>>() &&
-      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+      IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     safe_iterator_t<Rng>
       remove(Rng&& rng, const T& value, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I remove_if(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       remove_if(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -518,48 +518,48 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
       class Proj = identity>
     requires IndirectlyCopyable<I, O>() &&
-      IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+      IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
     tagged_pair<tag::in(I), tag::out(O)>
       remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class T, class Proj = identity>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-      IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+      IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       remove_copy(Rng&& rng, O result, const T& value, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O>()
     tagged_pair<tag::in(I), tag::out(O)>
       remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O>()
     tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
       remove_copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
+      IndirectRelation<projected<I, Proj>> R = equal_to<>>
     requires Permutable<I>()
     I unique(I first, S last, R comp = R{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+      IndirectRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       unique(Rng&& rng, R comp = R{}, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-      class Proj = identity, IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
+      class Proj = identity, IndirectRelation<projected<I, Proj>> R = equal_to<>>
     requires IndirectlyCopyable<I, O>() && (ForwardIterator<I>() ||
       ForwardIterator<O>() || IndirectlyCopyableStorable<I, O>())
     tagged_pair<tag::in(I), tag::out(O)>
       unique_copy(I first, S last, O result, R comp = R{}, Proj proj = Proj{});
 
   template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-      IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+      IndirectRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
     requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
       (ForwardIterator<iterator_t<Rng>>() || ForwardIterator<O>() ||
        IndirectlyCopyableStorable<iterator_t<Rng>, O>())
@@ -621,38 +621,38 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.partitions}, partitions:
   template <InputIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     bool is_partitioned(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     bool
       is_partitioned(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I partition(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       partition(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     requires Permutable<I>()
     I stable_partition(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <BidirectionalRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires Permutable<iterator_t<Rng>>()
     safe_iterator_t<Rng>
       stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{});
 
   template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncrementable O2,
-      class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
     requires IndirectlyCopyable<I, O1>() && IndirectlyCopyable<I, O2>()
     tagged_tuple<tag::in(I), tag::out1(O1), tag::out2(O2)>
       partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
@@ -660,18 +660,18 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   template <InputRange Rng, WeaklyIncrementable O1, WeaklyIncrementable O2,
       class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     requires IndirectlyCopyable<iterator_t<Rng>, O1>() &&
       IndirectlyCopyable<iterator_t<Rng>, O2>()
     tagged_tuple<tag::in(safe_iterator_t<Rng>), tag::out1(O1), tag::out2(O2)>
       partition_copy(Rng&& rng, O1 out_true, O2 out_false, Pred pred, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocablePredicate<projected<I, Proj>> Pred>
+      IndirectPredicate<projected<I, Proj>> Pred>
     I partition_point(I first, S last, Pred pred, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+      IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
     safe_iterator_t<Rng>
       partition_point(Rng&& rng, Pred pred, Proj proj = Proj{});
 
@@ -711,7 +711,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   template <InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2> S2,
       class Comp = less<>, class Proj1 = identity, class Proj2 = identity>
     requires IndirectlyCopyable<I1, I2>() && Sortable<I2, Comp, Proj2>() &&
-        IndirectInvocableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
+        IndirectStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
     I2
       partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                         Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -720,27 +720,27 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       class Proj1 = identity, class Proj2 = identity>
     requires IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>() &&
         Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
-        IndirectInvocableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
+        IndirectStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
           projected<iterator_t<Rng2>, Proj2>>()
     safe_iterator_t<Rng2>
       partial_sort_copy(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
                         Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     bool is_sorted(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       is_sorted(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I is_sorted_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       is_sorted_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
@@ -756,45 +756,45 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 
   // \ref{alg.binary.search}, binary search:
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     I
       lower_bound(I first, S last, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     I
       upper_bound(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       upper_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     tagged_pair<tag::begin(I), tag::end(I)>
       equal_range(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     tagged_pair<tag::begin(safe_iterator_t<Rng>),
                 tag::end(safe_iterator_t<Rng>)>
       equal_range(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
     bool
       binary_search(I first, S last, const T& value, Comp comp = Comp{},
                     Proj proj = Proj{});
 
   template <ForwardRange Rng, class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       binary_search(Rng&& rng, const T& value, Comp comp = Comp{},
                     Proj proj = Proj{});
@@ -832,14 +832,14 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
   // \ref{alg.set.operations}, set operations:
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
     bool
       includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+      IndirectStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
     bool
       includes(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -948,108 +948,108 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
       sort_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     bool is_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     bool
       is_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I is_heap_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <RandomAccessRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       is_heap_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   // \ref{alg.min.max}, minimum and maximum:
   template <class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr const T& min(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr T min(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     value_type_t<iterator_t<Rng>>
       min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr const T& max(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr T max(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     value_type_t<iterator_t<Rng>>
       max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <class T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
       minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <Copyable T, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
     constexpr tagged_pair<tag::min(T), tag::max(T)>
       minmax(initializer_list<T> t, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
     requires Copyable<value_type_t<iterator_t<Rng>>>()
     tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
                 tag::max(value_type_t<iterator_t<Rng>>)>
       minmax(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I min_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       min_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     I max_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     safe_iterator_t<Rng>
       max_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
     tagged_pair<tag::min(I), tag::max(I)>
       minmax_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <ForwardRange Rng, class Proj = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
     tagged_pair<tag::min(safe_iterator_t<Rng>),
                 tag::max(safe_iterator_t<Rng>)>
       minmax_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 
   template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
       class Proj1 = identity, class Proj2 = identity,
-      IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+      IndirectStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
     bool
       lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                               Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
   template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
       class Proj2 = identity,
-      IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+      IndirectStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
     bool
       lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -1221,11 +1221,11 @@ struct @\xname{input_getter}@ {
 \indexlibrary{\idxcode{all_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   bool all_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool all_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1247,11 +1247,11 @@ and \tcode{last - first} applications of the projection.
 \indexlibrary{\idxcode{any_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   bool any_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool any_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1273,11 +1273,11 @@ and \tcode{last - first} applications of the projection.
 \indexlibrary{\idxcode{none_of}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   bool none_of(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -1347,29 +1347,29 @@ If \tcode{f} returns a result, the result is ignored.
 \indexlibrary{\idxcode{find_if_not}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-  requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+  requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
   I find(I first, S last, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, class T, class Proj = identity>
-  requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+  requires IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   safe_iterator_t<Rng>
     find(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   I find_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     find_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   I find_if_not(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -1401,14 +1401,14 @@ applications of the corresponding predicate and projection.
 \begin{itemdecl}
 template <ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
     Sentinel<I2> S2, class Proj = identity,
-    IndirectInvocableRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
+    IndirectRelation<I2, projected<I1, Proj>> Pred = equal_to<>>
   I1
     find_end(I1 first1, S1 last1, I2 first2, S2 last2,
              Pred pred = Pred{}, Proj proj = Proj{});
 
 template <ForwardRange Rng1, ForwardRange Rng2,
     class Proj = identity,
-    IndirectInvocableRelation<iterator_t<Rng2>,
+    IndirectRelation<iterator_t<Rng2>,
       projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
   safe_iterator_t<Rng1>
     find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{});
@@ -1446,14 +1446,14 @@ applications of the corresponding predicate and projection.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   I1
     find_first_of(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
                   Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, ForwardRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
   safe_iterator_t<Rng1>
     find_first_of(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
@@ -1492,13 +1492,13 @@ applications of the corresponding predicate and the two projections.
 \indexlibrary{\idxcode{adjacent_find}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableRelation<projected<I, Proj>> Pred = equal_to<>>
+    IndirectRelation<projected<I, Proj>> Pred = equal_to<>>
   I
     adjacent_find(I first, S last, Pred pred = Pred{},
                   Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
+    IndirectRelation<projected<iterator_t<Rng>, Proj>> Pred = equal_to<>>
   safe_iterator_t<Rng>
     adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -1536,22 +1536,22 @@ return value, and no more than twice as many applications of the projection.
 \indexlibrary{\idxcode{count_if}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-  requires IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+  requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
   difference_type_t<I>
     count(I first, S last, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, class T, class Proj = identity>
-  requires IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+  requires IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   difference_type_t<iterator_t<Rng>>
     count(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   difference_type_t<I>
     count_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   difference_type_t<iterator_t<Rng>>
     count_if(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -1580,7 +1580,7 @@ applications of the corresponding predicate and projection.
 // \ref{depr.algo.range-and-a-half} (deprecated):
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -1588,7 +1588,7 @@ template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
 // \ref{depr.algo.range-and-a-half} (deprecated):
 template <InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
     mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},
@@ -1596,14 +1596,14 @@ template <InputRange Rng1, InputIterator I2,
 
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>)>
     mismatch(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
@@ -1926,13 +1926,13 @@ $i < n$, performs \tcode{*(result + i) = *(first + i)}.
 \indexlibrary{\idxcode{copy_n}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -2260,24 +2260,24 @@ in case of binary transform.
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T1, class T2, class Proj = identity>
   requires Writable<I, const T2&>() &&
-    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+    IndirectRelation<equal_to<>, projected<I, Proj>, const T1*>()
   I
     replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T1, class T2, class Proj = identity>
   requires Writable<iterator_t<Rng>, const T2&>() &&
-    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+    IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
   safe_iterator_t<Rng>
     replace(Rng&& rng, const T1& old_value, const T2& new_value, Proj proj = Proj{});
 
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   requires Writable<I, const T&>()
   I
     replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Writable<iterator_t<Rng>, const T&>()
   safe_iterator_t<Rng>
     replace_if(Rng&& rng, Pred pred, const T& new_value, Proj proj = Proj{});
@@ -2311,7 +2311,7 @@ applications of the corresponding predicate and projection.
 template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<const T2&> O,
     class Proj = identity>
   requires IndirectlyCopyable<I, O>() &&
-    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T1*>()
+    IndirectRelation<equal_to<>, projected<I, Proj>, const T1*>()
   tagged_pair<tag::in(I), tag::out(O)>
     replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                  Proj proj = Proj{});
@@ -2319,20 +2319,20 @@ template <InputIterator I, Sentinel<I> S, class T1, class T2, OutputIterator<con
 template <InputRange Rng, class T1, class T2, OutputIterator<const T2&> O,
     class Proj = identity>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
+    IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     replace_copy(Rng&& rng, O result, const T1& old_value, const T2& new_value,
                  Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, class T, OutputIterator<const T&> O,
-    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                     Proj proj = Proj{});
 
 template <InputRange Rng, class T, OutputIterator<const T&> O, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     replace_copy_if(Rng&& rng, O result, Pred pred, const T& new_value,
@@ -2453,22 +2453,22 @@ Exactly
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
   requires Permutable<I>() &&
-    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
   I remove(I first, S last, const T& value, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity>
   requires Permutable<iterator_t<Rng>>() &&
-    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   safe_iterator_t<Rng>
     remove(Rng&& rng, const T& value, Proj proj = Proj{});
 
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I remove_if(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     remove_if(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2510,24 +2510,24 @@ in that range.
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
     class Proj = identity>
   requires IndirectlyCopyable<I, O>() &&
-    IndirectInvocableRelation<equal_to<>, projected<I, Proj>, const T*>()
+    IndirectRelation<equal_to<>, projected<I, Proj>, const T*>()
   tagged_pair<tag::in(I), tag::out(O)>
     remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class T, class Proj = identity>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
-    IndirectInvocableRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
+    IndirectRelation<equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     remove_copy(Rng&& rng, O result, const T& value, Proj proj = Proj{});
 
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O>()
   tagged_pair<tag::in(I), tag::out(O)>
     remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O>()
   tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
     remove_copy_if(Rng&& rng, O result, Pred pred, Proj proj = Proj{});
@@ -2571,12 +2571,12 @@ applications of the corresponding predicate and projection.
 \indexlibrary{\idxcode{unique}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
+    IndirectRelation<projected<I, Proj>> R = equal_to<>>
   requires Permutable<I>()
   I unique(I first, S last, R comp = R{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+    IndirectRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     unique(Rng&& rng, R comp = R{}, Proj proj = Proj{});
@@ -2610,14 +2610,14 @@ applications of the projection.
 \indexlibrary{\idxcode{unique_copy}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-    class Proj = identity, IndirectInvocableRelation<projected<I, Proj>> R = equal_to<>>
+    class Proj = identity, IndirectRelation<projected<I, Proj>> R = equal_to<>>
   requires IndirectlyCopyable<I, O>() && (ForwardIterator<I>() ||
     ForwardIterator<O>() || IndirectlyCopyableStorable<I, O>())
   tagged_pair<tag::in(I), tag::out(O)>
     unique_copy(I first, S last, O result, R comp = R{}, Proj proj = Proj{});
 
 template <InputRange Rng, WeaklyIncrementable O, class Proj = identity,
-    IndirectInvocableRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
+    IndirectRelation<projected<iterator_t<Rng>, Proj>> R = equal_to<>>
   requires IndirectlyCopyable<iterator_t<Rng>, O>() &&
     (ForwardIterator<iterator_t<Rng>>() || ForwardIterator<O>() ||
      IndirectlyCopyableStorable<iterator_t<Rng>, O>())
@@ -2873,11 +2873,11 @@ randomness.
 \indexlibrary{\idxcode{is_partitioned}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   bool is_partitioned(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   bool
     is_partitioned(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -2898,12 +2898,12 @@ for every \tcode{i} in \range{first}{last}.
 \indexlibrary{\idxcode{partition}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I partition(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     partition(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2931,12 +2931,12 @@ Exactly \tcode{last - first} applications of the predicate and projection.
 \indexlibrary{\idxcode{stable_partition}}%
 \begin{itemdecl}
 template <BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   requires Permutable<I>()
   I stable_partition(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <BidirectionalRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires Permutable<iterator_t<Rng>>()
   safe_iterator_t<Rng>
     stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{});
@@ -2978,7 +2978,7 @@ applications of the predicate and projection.
 \indexlibrary{\idxcode{partition_copy}}%
 \begin{itemdecl}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncrementable O2,
-    class Proj = identity, IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    class Proj = identity, IndirectPredicate<projected<I, Proj>> Pred>
   requires IndirectlyCopyable<I, O1>() && IndirectlyCopyable<I, O2>()
   tagged_tuple<tag::in(I), tag::out1(O1), tag::out2(O2)>
     partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
@@ -2986,7 +2986,7 @@ template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1, WeaklyIncremen
 
 template <InputRange Rng, WeaklyIncrementable O1, WeaklyIncrementable O2,
     class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   requires IndirectlyCopyable<iterator_t<Rng>, O1>() &&
     IndirectlyCopyable<iterator_t<Rng>, O2>()
   tagged_tuple<tag::in(safe_iterator_t<Rng>), tag::out1(O1), tag::out2(O2)>
@@ -3016,11 +3016,11 @@ and \tcode{get<2>(p)} is the end of the output range beginning at \tcode{out_fal
 \indexlibrary{\idxcode{partition_point}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocablePredicate<projected<I, Proj>> Pred>
+    IndirectPredicate<projected<I, Proj>> Pred>
   I partition_point(I first, S last, Pred pred, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng>, Proj>> Pred>
+    IndirectPredicate<projected<iterator_t<Rng>, Proj>> Pred>
   safe_iterator_t<Rng>
     partition_point(Rng&& rng, Pred pred, Proj proj = Proj{});
 \end{itemdecl}
@@ -3207,7 +3207,7 @@ comparisons.
 template <InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2> S2,
     class Comp = less<>, class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyCopyable<I1, I2>() && Sortable<I2, Comp, Proj2>() &&
-      IndirectInvocableStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
+      IndirectStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
   I2
     partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                       Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
@@ -3216,7 +3216,7 @@ template <InputRange Rng1, RandomAccessRange Rng2, class Comp = less<>,
     class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>() &&
       Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
-      IndirectInvocableStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
+      IndirectStrictWeakOrder<Comp, projected<iterator_t<Rng1>, Proj1>,
         projected<iterator_t<Rng2>, Proj2>>()
   safe_iterator_t<Rng2>
     partial_sort_copy(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
@@ -3249,11 +3249,11 @@ comparisons.
 \indexlibrary{\idxcode{is_sorted}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   bool is_sorted(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     is_sorted(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3266,11 +3266,11 @@ template <ForwardRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{is_sorted_until}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I is_sorted_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     is_sorted_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3343,13 +3343,13 @@ For non-random access iterators they execute a linear number of steps.
 \indexlibrary{\idxcode{lower_bound}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   I
     lower_bound(I first, S last, const T& value, Comp comp = Comp{},
                 Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3389,12 +3389,12 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{upper_bound}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   I
     upper_bound(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     upper_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -3434,12 +3434,12 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{equal_range}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   tagged_pair<tag::begin(I), tag::end(I)>
     equal_range(I first, S last, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   tagged_pair<tag::begin(safe_iterator_t<Rng>),
               tag::end(safe_iterator_t<Rng>)>
     equal_range(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{});
@@ -3483,13 +3483,13 @@ applications of the comparison function and projection.
 \indexlibrary{\idxcode{binary_search}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less<>>
   bool
     binary_search(I first, S last, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
 
 template <ForwardRange Rng, class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<const T*, projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     binary_search(Rng&& rng, const T& value, Comp comp = Comp{},
                   Proj proj = Proj{});
@@ -3667,14 +3667,14 @@ to contain the minimum, and so on.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
   bool
     includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = Comp{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+    IndirectStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
   bool
     includes(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
@@ -4100,11 +4100,11 @@ comparisons (where
 \indexlibrary{\idxcode{is_heap}}%
 \begin{itemdecl}
 template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   bool is_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <RandomAccessRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   bool
     is_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4117,11 +4117,11 @@ template <RandomAccessRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{is_heap_until}}%
 \begin{itemdecl}
 template <RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I is_heap_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <RandomAccessRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     is_heap_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4142,7 +4142,7 @@ range \range{first}{i} is a heap.
 \indexlibrary{\idxcode{min}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr const T& min(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -4159,11 +4159,11 @@ Returns the first argument when the arguments are equivalent.
 \indexlibrary{\idxcode{min}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr T min(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   value_type_t<iterator_t<Rng>>
     min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4183,7 +4183,7 @@ template <InputRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{max}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr const T& max(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
 
@@ -4200,11 +4200,11 @@ Returns the first argument when the arguments are equivalent.
 \indexlibrary{\idxcode{max}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr T max(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   value_type_t<iterator_t<Rng>>
     max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4224,7 +4224,7 @@ template <InputRange Rng, class Proj = identity,
 \indexlibrary{\idxcode{minmax}}%
 \begin{itemdecl}
 template <class T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
     minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4248,12 +4248,12 @@ Exactly one comparison and exactly two applications of the projection.
 \indexlibrary{\idxcode{minmax}}%
 \begin{itemdecl}
 template <Copyable T, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less<>>
   constexpr tagged_pair<tag::min(T), tag::max(T)>
     minmax(initializer_list<T> rng, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <InputRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj> Comp = less<>>
   requires Copyable<value_type_t<iterator_t<Rng>>>()
   tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
               tag::max(value_type_t<iterator_t<Rng>>)>
@@ -4281,11 +4281,11 @@ applications of the corresponding predicate, and at most twice as many applicati
 \indexlibrary{\idxcode{min_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I min_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     min_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4319,11 +4319,11 @@ exactly twice as many applications of the projection.
 \indexlibrary{\idxcode{max_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   I max_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   safe_iterator_t<Rng>
     max_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
 \end{itemdecl}
@@ -4357,12 +4357,12 @@ exactly twice as many applications of the projection.
 \indexlibrary{\idxcode{minmax_element}}%
 \begin{itemdecl}
 template <ForwardIterator I, Sentinel<I> S, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<I, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I, Proj>> Comp = less<>>
   tagged_pair<tag::min(I), tag::max(I)>
     minmax_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{});
 
 template <ForwardRange Rng, class Proj = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less<>>
   tagged_pair<tag::min(safe_iterator_t<Rng>),
               tag::max(safe_iterator_t<Rng>)>
     minmax_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{});
@@ -4392,14 +4392,14 @@ where $N$ is \tcode{distance(first, last)}.
 \begin{itemdecl}
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocableStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
+    IndirectStrictWeakOrder<projected<I1, Proj1>, projected<I2, Proj2>> Comp = less<>>
   bool
     lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                             Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputRange Rng2, class Proj1 = identity,
     class Proj2 = identity,
-    IndirectInvocableStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+    IndirectStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
       projected<iterator_t<Rng2>, Proj2>> Comp = less<>>
   bool
     lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},

--- a/compatibility.tex
+++ b/compatibility.tex
@@ -127,11 +127,11 @@ same), and even when the probe is needed, in no cases does this change the compe
 any algorithm.
 \end{itemize}
 
-\rSec2[diff.n3351.invok_proj]{Callables and Projections}
+\rSec2[diff.n3351.invok_proj]{Invocables and Projections}
 
 \pnum
 Adobe's Source Libraries~\cite{ASL} pioneered the use of \techterm{callables} and
-\techterm{projections} in the standard algorithms. Callables let users pass member pointers
+\techterm{projections} in the standard algorithms. Invocables let users pass member pointers
 where the algorithms expect callables, saving users the trouble of using a binder or a lambda.
 Projections are extra optional arguments that give users a way to trivially transform input data
 on the fly during the execution of the algorithms. Neither significantly changes the operational

--- a/concepts.tex
+++ b/concepts.tex
@@ -19,7 +19,7 @@ as summarized in Table~\ref{tab:concepts.lib.summary}.
 \ref{concepts.lib.corelang}   & Core language concepts         &   \tcode{<experimental/ranges/concepts>}      \\
 \ref{concepts.lib.compare}    & Comparison concepts            &                      \\
 \ref{concepts.lib.object}     & Object concepts                &                      \\
-\ref{concepts.lib.callables}  & Callable concepts              &                      \\
+\ref{concepts.lib.callable}   & Callable concepts              &                      \\
 \end{libsumtab}
 
 \pnum
@@ -868,25 +868,25 @@ concept bool Regular() {
 similarly to built-in types like \tcode{int} and that are comparable with \tcode{==}.\exitnote
 \end{itemdescr}
 
-\rSec1[concepts.lib.callables]{Callable concepts}
+\rSec1[concepts.lib.callable]{Callable concepts}
 
-\rSec2[concepts.lib.callables.general]{In general}
+\rSec2[concepts.lib.callable.general]{In general}
 
 \pnum
 The concepts in this section describe the requirements on function
 objects~(\ref{function.objects}) and their arguments.
 
-\rSec2[concepts.lib.callables.callable]{Concept \tcode{Callable}}
+\rSec2[concepts.lib.callable.invocable]{Concept \tcode{Invocable}}
 
 \pnum
-The \tcode{Callable} concept specifies a relationship between a callable
+The \tcode{Invocable} concept specifies a relationship between a callable
 type~(\cxxref{func.def}) \tcode{F} and a set of argument types \tcode{Args...} which
 can be evaluated by the library function \tcode{invoke}~(\ref{func.invoke}).
 
-\indexlibrary{\idxcode{Callable}}%
+\indexlibrary{\idxcode{Invocable}}%
 \begin{itemdecl}
 template <class F, class... Args>
-concept bool Callable() {
+concept bool Invocable() {
   return CopyConstructible<F>() &&
     requires(F f, Args&&... args) {
       invoke(f, std::forward<Args>(args)...); // not required to be equality preserving
@@ -899,16 +899,16 @@ concept bool Callable() {
 \enternote Since the \tcode{invoke} function call
 expression is not required to be
 equality-preserving~(\ref{concepts.lib.general.equality}), a function that generates random numbers
-may satisfy \tcode{Callable}.\exitnote
+may satisfy \tcode{Invocable}.\exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.regularcallable]{Concept \tcode{RegularCallable}}
+\rSec2[concepts.lib.callable.regularinvocable]{Concept \tcode{RegularInvocable}}
 
-\indexlibrary{\idxcode{RegularCallable}}%
+\indexlibrary{\idxcode{RegularInvocable}}%
 \begin{itemdecl}
 template <class F, class... Args>
-concept bool RegularCallable() {
-  return Callable<F, Args...>();
+concept bool RegularInvocable() {
+  return Invocable<F, Args...>();
 }
 \end{itemdecl}
 
@@ -916,29 +916,29 @@ concept bool RegularCallable() {
 \pnum
 The \tcode{invoke} function call expression shall be
 equality-preserving~(\ref{concepts.lib.general.equality}). \enternote This requirement supersedes the
-annotation in the definition of \tcode{Callable}. \exitnote
+annotation in the definition of \tcode{Invocable}. \exitnote
 
 \pnum
 \enternote A random number generator does not satisfy
-\tcode{RegularCallable}.\exitnote
+\tcode{RegularInvocable}.\exitnote
 
 \pnum
-\enternote The distinction between \tcode{Callable} and
-\tcode{RegularCallable} is purely semantic.\exitnote
+\enternote The distinction between \tcode{Invocable} and
+\tcode{RegularInvocable} is purely semantic.\exitnote
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.predicate]{Concept \tcode{Predicate}}
+\rSec2[concepts.lib.callable.predicate]{Concept \tcode{Predicate}}
 
 \indexlibrary{\idxcode{Predicate}}%
 \begin{itemdecl}
 template <class F, class... Args>
 concept bool Predicate() {
-  return RegularCallable<F, Args...>() &&
+  return RegularInvocable<F, Args...>() &&
     Boolean<result_of_t<F&(Args...)>>();
 }
 \end{itemdecl}
 
-\rSec2[concepts.lib.callables.relation]{Concept \tcode{Relation}}
+\rSec2[concepts.lib.callable.relation]{Concept \tcode{Relation}}
 
 \indexlibrary{\idxcode{Relation}}%
 \begin{itemdecl}
@@ -973,7 +973,7 @@ Then \tcode{Relation<R, T, U>()} is satisfied if and only if
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concepts.lib.callables.strictweakorder]{Concept \tcode{StrictWeakOrder}}
+\rSec2[concepts.lib.callable.strictweakorder]{Concept \tcode{StrictWeakOrder}}
 
 \indexlibrary{\idxcode{Relation}}%
 \begin{itemdecl}

--- a/deprecated.tex
+++ b/deprecated.tex
@@ -35,14 +35,14 @@ The following algorithms are deemed unsafe and are deprecated in this document.
 // \ref{mismatch}, mismatch
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectPredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectPredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
     mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},

--- a/deprecated.tex
+++ b/deprecated.tex
@@ -35,14 +35,14 @@ The following algorithms are deemed unsafe and are deprecated in this document.
 // \ref{mismatch}, mismatch
 template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+    IndirectInvocablePredicate<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(I1), tag::in2(I2)>
     mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
              Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{});
 
 template <InputRange Rng1, InputIterator I2,
     class Proj1 = identity, class Proj2 = identity,
-    IndirectCallablePredicate<projected<iterator_t<Rng1>, Proj1>,
+    IndirectInvocablePredicate<projected<iterator_t<Rng1>, Proj1>,
       projected<I2, Proj2>> Pred = equal_to<>>
   tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(I2)>
     mismatch(Rng1&& rng1, I2 first2, Pred pred = Pred{},

--- a/iterators.tex
+++ b/iterators.tex
@@ -728,78 +728,78 @@ from \tcode{a}. Let \tcode{n} be the smallest value of type
 \item If \tcode{b} is dereferenceable, then \tcode{a[n]} is valid and is equal to \tcode{*b}.
 \end{itemize}
 
-\rSec1[indirectcallables]{Indirect callable requirements}
+\rSec1[indirectcallable]{Indirect callable requirements}
 
-\rSec2[indirectcallables.general]{In general}
+\rSec2[indirectcallable.general]{In general}
 
 \pnum
 There are several concepts that group requirements of algorithms that take callable
 objects~(\cxxref{func.require}) as arguments.
 
-\rSec2[indirectcallables.indirectfunc]{Indirect callables}
+\rSec2[indirectcallable.indirectinvocable]{Indirect callables}
 
 \pnum
 The indirect callable concepts are used to constrain those algorithms that accept
 callable objects~(\cxxref{func.def}) as arguments.
 
-\indexlibrary{\idxcode{indirect_result_of_t}}%
-\indexlibrary{\idxcode{IndirectCallable}}%
-\indexlibrary{\idxcode{IndirectRegularCallable}}%
-\indexlibrary{\idxcode{IndirectCallablePredicate}}%
-\indexlibrary{\idxcode{IndirectCallableRelation}}%
-\indexlibrary{\idxcode{IndirectCallableStrictWeakOrder}}%
+\indexlibrary{\idxcode{indirect_result_of}}%
+\indexlibrary{\idxcode{IndirectInvocable}}%
+\indexlibrary{\idxcode{IndirectRegularInvocable}}%
+\indexlibrary{\idxcode{IndirectInvocablePredicate}}%
+\indexlibrary{\idxcode{IndirectInvocableRelation}}%
+\indexlibrary{\idxcode{IndirectInvocableStrictWeakOrder}}%
 \begin{codeblock}
   template <class F>
-  concept bool IndirectCallable() {
-    return Callable<F>();
+  concept bool IndirectInvocable() {
+    return Invocable<F>();
   }
   template <class F, class I>
-  concept bool IndirectCallable() {
+  concept bool IndirectInvocable() {
     return Readable<I>() &&
-      Callable<F, value_type_t<I>>() &&
-      Callable<F, reference_t<I>>() &&
-      Callable<F, iter_common_reference_t<I>>();
+      Invocable<F, value_type_t<I>>() &&
+      Invocable<F, reference_t<I>>() &&
+      Invocable<F, iter_common_reference_t<I>>();
   }
   template <class F, class I1, class I2>
-  concept bool IndirectCallable() {
+  concept bool IndirectInvocable() {
     return Readable<I1>() && Readable<I2>() &&
-      Callable<F, value_type_t<I1>, value_type_t<I2>>() &&
-      Callable<F, value_type_t<I1>, reference_t<I2>>() &&
-      Callable<F, reference_t<I1>, value_type_t<I2>>() &&
-      Callable<F, reference_t<I1>, reference_t<I2>>() &&
-      Callable<F, iter_common_reference_t<I1>, iter_common_reference_t<I2>>();
+      Invocable<F, value_type_t<I1>, value_type_t<I2>>() &&
+      Invocable<F, value_type_t<I1>, reference_t<I2>>() &&
+      Invocable<F, reference_t<I1>, value_type_t<I2>>() &&
+      Invocable<F, reference_t<I1>, reference_t<I2>>() &&
+      Invocable<F, iter_common_reference_t<I1>, iter_common_reference_t<I2>>();
   }
 
   template <class F>
-  concept bool IndirectRegularCallable() {
-    return RegularCallable<F>();
+  concept bool IndirectRegularInvocable() {
+    return RegularInvocable<F>();
   }
   template <class F, class I>
-  concept bool IndirectRegularCallable() {
+  concept bool IndirectRegularInvocable() {
     return Readable<I>() &&
-      RegularCallable<F, value_type_t<I>>() &&
-      RegularCallable<F, reference_t<I>>() &&
-      RegularCallable<F, iter_common_reference_t<I>>();
+      RegularInvocable<F, value_type_t<I>>() &&
+      RegularInvocable<F, reference_t<I>>() &&
+      RegularInvocable<F, iter_common_reference_t<I>>();
   }
   template <class F, class I1, class I2>
-  concept bool IndirectRegularCallable() {
+  concept bool IndirectRegularInvocable() {
     return Readable<I1>() && Readable<I2>() &&
-      RegularCallable<F, value_type_t<I1>, value_type_t<I2>>() &&
-      RegularCallable<F, value_type_t<I1>, reference_t<I2>>() &&
-      RegularCallable<F, reference_t<I1>, value_type_t<I2>>() &&
-      RegularCallable<F, reference_t<I1>, reference_t<I2>>() &&
-      RegularCallable<F, iter_common_reference_t<I1>, iter_common_reference_t<I2>>();
+      RegularInvocable<F, value_type_t<I1>, value_type_t<I2>>() &&
+      RegularInvocable<F, value_type_t<I1>, reference_t<I2>>() &&
+      RegularInvocable<F, reference_t<I1>, value_type_t<I2>>() &&
+      RegularInvocable<F, reference_t<I1>, reference_t<I2>>() &&
+      RegularInvocable<F, iter_common_reference_t<I1>, iter_common_reference_t<I2>>();
   }
 
   template <class F, class I>
-  concept bool IndirectCallablePredicate() {
+  concept bool IndirectInvocablePredicate() {
     return Readable<I>() &&
       Predicate<F, value_type_t<I>>() &&
       Predicate<F, reference_t<I>>() &&
       Predicate<F, iter_common_reference_t<I>>();
   }
   template <class F, class I1, class I2>
-  concept bool IndirectCallablePredicate() {
+  concept bool IndirectInvocablePredicate() {
     return Readable<I1>() && Readable<I2>() &&
       Predicate<F, value_type_t<I1>, value_type_t<I2>>() &&
       Predicate<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -809,7 +809,7 @@ callable objects~(\cxxref{func.def}) as arguments.
   }
 
   template <class F, class I1, class I2 = I1>
-  concept bool IndirectCallableRelation() {
+  concept bool IndirectInvocableRelation() {
     return Readable<I1>() && Readable<I2>() &&
       Relation<F, value_type_t<I1>, value_type_t<I2>>() &&
       Relation<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -819,7 +819,7 @@ callable objects~(\cxxref{func.def}) as arguments.
   }
 
   template <class F, class I1, class I2 = I1>
-  concept bool IndirectCallableStrictWeakOrder() {
+  concept bool IndirectInvocableStrictWeakOrder() {
     return Readable<I1>() && Readable<I2>() &&
       StrictWeakOrder<F, value_type_t<I1>, value_type_t<I2>>() &&
       StrictWeakOrder<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -831,7 +831,7 @@ callable objects~(\cxxref{func.def}) as arguments.
   template <class> struct indirect_result_of { };
 
   template <class F, class... Is>
-    requires IndirectCallable<F, Is...>()
+    requires IndirectInvocable<F, Is...>()
   struct indirect_result_of<F(Is...)> :
     result_of<F(reference_t<Is>...)> { };
 
@@ -851,7 +851,7 @@ algorithms that accept callable objects and projections. It bundles a \tcode{Rea
 
 \indexlibrary{\idxcode{projected}}%
 \begin{codeblock}
-  template <Readable I, IndirectRegularCallable<I> Proj>
+  template <Readable I, IndirectRegularInvocable<I> Proj>
   struct projected {
     using value_type = decay_t<indirect_result_of_t<Proj&(I)>>;
     indirect_result_of_t<Proj&(I)> operator*() const;
@@ -986,7 +986,7 @@ compare values from two different sequences.
   template <class I1, class I2, class R = equal_to<>, class P1 = identity,
     class P2 = identity>
   concept bool IndirectlyComparable() {
-    return IndirectCallableRelation<R, projected<I1, P1>, projected<I2, P2>>();
+    return IndirectInvocableRelation<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
 
@@ -1022,7 +1022,7 @@ algorithms that merge sorted sequences into an output sequence by copying elemen
       WeaklyIncrementable<Out>() &&
       IndirectlyCopyable<I1, Out>() &&
       IndirectlyCopyable<I2, Out>() &&
-      IndirectCallableStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>();
+      IndirectInvocableStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
 
@@ -1037,7 +1037,7 @@ sequences into ordered sequences (e.g., \tcode{sort}).
   template <class I, class R = less<>, class P = identity>
   concept bool Sortable() {
     return Permutable<I>() &&
-      IndirectCallableStrictWeakOrder<R, projected<I, P>>();
+      IndirectInvocableStrictWeakOrder<R, projected<I, P>>();
   }
 \end{codeblock}
 
@@ -3166,7 +3166,7 @@ ranges together with \tcode{move_iterator}. When an input iterator type
 
 \begin{codeblock}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-          IndirectCallablePredicate<I> Pred>
+          IndirectInvocablePredicate<I> Pred>
   requires IndirectlyMovable<I, O>()
 void move_if(I first, S last, O out, Pred pred)
 {

--- a/iterators.tex
+++ b/iterators.tex
@@ -745,9 +745,9 @@ callable objects~(\cxxref{func.def}) as arguments.
 \indexlibrary{\idxcode{indirect_result_of}}%
 \indexlibrary{\idxcode{IndirectInvocable}}%
 \indexlibrary{\idxcode{IndirectRegularInvocable}}%
-\indexlibrary{\idxcode{IndirectInvocablePredicate}}%
-\indexlibrary{\idxcode{IndirectInvocableRelation}}%
-\indexlibrary{\idxcode{IndirectInvocableStrictWeakOrder}}%
+\indexlibrary{\idxcode{IndirectPredicate}}%
+\indexlibrary{\idxcode{IndirectRelation}}%
+\indexlibrary{\idxcode{IndirectStrictWeakOrder}}%
 \begin{codeblock}
   template <class F>
   concept bool IndirectInvocable() {
@@ -792,14 +792,14 @@ callable objects~(\cxxref{func.def}) as arguments.
   }
 
   template <class F, class I>
-  concept bool IndirectInvocablePredicate() {
+  concept bool IndirectPredicate() {
     return Readable<I>() &&
       Predicate<F, value_type_t<I>>() &&
       Predicate<F, reference_t<I>>() &&
       Predicate<F, iter_common_reference_t<I>>();
   }
   template <class F, class I1, class I2>
-  concept bool IndirectInvocablePredicate() {
+  concept bool IndirectPredicate() {
     return Readable<I1>() && Readable<I2>() &&
       Predicate<F, value_type_t<I1>, value_type_t<I2>>() &&
       Predicate<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -809,7 +809,7 @@ callable objects~(\cxxref{func.def}) as arguments.
   }
 
   template <class F, class I1, class I2 = I1>
-  concept bool IndirectInvocableRelation() {
+  concept bool IndirectRelation() {
     return Readable<I1>() && Readable<I2>() &&
       Relation<F, value_type_t<I1>, value_type_t<I2>>() &&
       Relation<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -819,7 +819,7 @@ callable objects~(\cxxref{func.def}) as arguments.
   }
 
   template <class F, class I1, class I2 = I1>
-  concept bool IndirectInvocableStrictWeakOrder() {
+  concept bool IndirectStrictWeakOrder() {
     return Readable<I1>() && Readable<I2>() &&
       StrictWeakOrder<F, value_type_t<I1>, value_type_t<I2>>() &&
       StrictWeakOrder<F, value_type_t<I1>, reference_t<I2>>() &&
@@ -986,7 +986,7 @@ compare values from two different sequences.
   template <class I1, class I2, class R = equal_to<>, class P1 = identity,
     class P2 = identity>
   concept bool IndirectlyComparable() {
-    return IndirectInvocableRelation<R, projected<I1, P1>, projected<I2, P2>>();
+    return IndirectRelation<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
 
@@ -1022,7 +1022,7 @@ algorithms that merge sorted sequences into an output sequence by copying elemen
       WeaklyIncrementable<Out>() &&
       IndirectlyCopyable<I1, Out>() &&
       IndirectlyCopyable<I2, Out>() &&
-      IndirectInvocableStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>();
+      IndirectStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>();
   }
 \end{codeblock}
 
@@ -1037,7 +1037,7 @@ sequences into ordered sequences (e.g., \tcode{sort}).
   template <class I, class R = less<>, class P = identity>
   concept bool Sortable() {
     return Permutable<I>() &&
-      IndirectInvocableStrictWeakOrder<R, projected<I, P>>();
+      IndirectStrictWeakOrder<R, projected<I, P>>();
   }
 \end{codeblock}
 
@@ -3166,7 +3166,7 @@ ranges together with \tcode{move_iterator}. When an input iterator type
 
 \begin{codeblock}
 template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-          IndirectInvocablePredicate<I> Pred>
+          IndirectPredicate<I> Pred>
   requires IndirectlyMovable<I, O>()
 void move_if(I first, S last, O out, Pred pred)
 {

--- a/lib-intro.tex
+++ b/lib-intro.tex
@@ -211,7 +211,7 @@ be equal.
 
 \pnum
 The type of a customization point object \tcode{T} shall satisfy
-\tcode{Callable<const T, Args...>()}~(\ref{concepts.lib.callables.callable}) when the types of
+\tcode{Invocable<const T, Args...>()}~(\ref{concepts.lib.callable.invocable}) when the types of
 \tcode{Args...} meet the requirements specified in that
 customization point object's definition. Otherwise, \tcode{T}
 shall not have a function call operator that participates in


### PR DESCRIPTION
Since the term of art for these things is still "callable" in C++14 (and in C++17?), I am leaving the term "indirect callable" as the term of art, but only renaming the concepts themselves.

PR against master since this seems editorial to me.