### PR TITLE
Review: front matter for [move.sentinel]

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -3130,7 +3130,9 @@ template <class Container>
 \tcode{insert_iterator<Container>(x, i)}.
 \end{itemdescr}
 
-\rSec2[iterators.move]{Move iterators}
+\rSec2[iterators.move]{Move iterators and sentinels}
+
+\rSec3[move.iterator]{Class template \tcode{move_iterator}}
 
 \pnum
 Class template \tcode{move_iterator} is an iterator adaptor
@@ -3153,30 +3155,6 @@ vector<string> v2(make_move_iterator(s.begin()),
 \end{codeblock}
 
 \exitexample
-
-\pnum
-Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
-ranges together with \tcode{move_iterator}. When an input iterator type
-\tcode{I} and sentinel type \tcode{S} satisfy \tcode{Sentinel<S, I>()},
-\tcode{Sentinel<move_sentinel<S>, move_iterator<I>{>}()} is satisfied as well.
-
-\pnum
-\enterexample A \tcode{move_if} algorithm is easily implemented with
-\tcode{copy_if} using \tcode{move_iterator} and \tcode{move_sentinel}:
-
-\begin{codeblock}
-template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-          IndirectPredicate<I> Pred>
-  requires IndirectlyMovable<I, O>()
-void move_if(I first, S last, O out, Pred pred)
-{
-  copy_if(move_iterator<I>{first}, move_sentinel<S>{last}, out, pred);
-}
-\end{codeblock}
-
-\exitexample
-
-\rSec3[move.iterator]{Class template \tcode{move_iterator}}
 
 \indexlibrary{\idxcode{move_iterator}}%
 \begin{codeblock}
@@ -3636,6 +3614,28 @@ template <InputIterator I>
 \end{itemdescr}
 
 \rSec3[move.sentinel]{Class template \tcode{move_sentinel}}
+
+\pnum
+Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
+ranges together with \tcode{move_iterator}. When an input iterator type
+\tcode{I} and sentinel type \tcode{S} satisfy \tcode{Sentinel<S, I>()},
+\tcode{Sentinel<move_sentinel<S>, move_iterator<I>{>}()} is satisfied as well.
+
+\pnum
+\enterexample A \tcode{move_if} algorithm is easily implemented with
+\tcode{copy_if} using \tcode{move_iterator} and \tcode{move_sentinel}:
+
+\begin{codeblock}
+template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
+          IndirectPredicate<I> Pred>
+  requires IndirectlyMovable<I, O>()
+void move_if(I first, S last, O out, Pred pred)
+{
+  copy_if(move_iterator<I>{first}, move_sentinel<S>{last}, out, pred);
+}
+\end{codeblock}
+
+\exitexample
 
 \indexlibrary{\idxcode{move_sentinel}}%
 \begin{codeblock}


### PR DESCRIPTION
* Retitle [iterators.move] as "Move iterators and sentinels."

* Split the front matter from [iterators.move] out into [move.iterator] and [move.sentinel].
