### PR TITLE
Front matter for [counted.iterator]

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -4200,6 +4200,8 @@ of their range (e.g., \tcode{counted_iterator}~(\ref{counted.iterator})).
 
 \rSec2[iterators.counted]{Counted iterators}
 
+\rSec3[counted.iterator]{Class template \tcode{counted_iterator}}
+
 \pnum
 Class template \tcode{counted_iterator} is an iterator adaptor
 with the same behavior as the underlying iterator except that it
@@ -4224,8 +4226,6 @@ Two values \tcode{i1} and \tcode{i2} of (possibly differing) types
 \tcode{counted_iterator<I1>} and \tcode{counted_iterator<I2>} refer to
 elements of the same sequence if and only if \tcode{next(i1.base(), i1.count())}
 and \tcode{next(i2.base(), i2.count())} refer to the same (possibly past-the-end) element.
-
-\rSec3[counted.iterator]{Class template \tcode{counted_iterator}}
 
 \indexlibrary{\idxcode{counted_iterator}}%
 \begin{codeblock}


### PR DESCRIPTION
* Relocate introductory material from [iterators.counted] into [counted.iterator] to be consistent with more recent library wording style.