### PR TITLE
[Editorial] "This paper" => "This document"

### DIFF
--- a/acknowledgements.tex
+++ b/acknowledgements.tex
@@ -12,7 +12,7 @@ for his help formalizing the ideas of the range-v3 library~\cite{range-v3} on wh
 work is based, and for his review of this document.
 
 Sean Parent has made major contributions to both the foundations and the wording of this
-paper.
+document.
 
 Stephan T. Lavavej offered a careful review of much of this document, a non-trivial undertaking.
 

--- a/compatibility.tex
+++ b/compatibility.tex
@@ -148,7 +148,7 @@ In the Palo Alto report, the \tcode{WeaklyIncrementable} concept has an associat
 called \tcode{DifferenceType}. The latter is required to be convertible to the former, but they are
 not required to be the same type. (\tcode{DifferenceType} is required to be a signed integral type,
 but \tcode{DistanceType} need not be signed.) Although sensible from a soundness point of view,
-the author of this paper feels this is potentially a rich source of confusion. This paper hews
+the author of this document feels this is potentially a rich source of confusion. This document hews
 closer to the current standard by having only one associated type, \tcode{DifferenceType}, and
 requiring it to be signed.
 

--- a/intro.tex
+++ b/intro.tex
@@ -53,12 +53,12 @@ the new iterator range requirements~(\ref{iterator.range}).
 \end{itemize}
 
 \pnum
-This paper does not specify constrained analogues of other parts of the Standard
+This document does not specify constrained analogues of other parts of the Standard
 Library (e.g., the numeric algorithms), nor does it add range support to all the
 places that could benefit from it (e.g., the containers).
 
 \pnum
-This paper does not specify any new range views, actions, or facade or adaptor
+This document does not specify any new range views, actions, or facade or adaptor
 utilities; all are left as future work.
 
 \rSec1[intro.refs]{References}
@@ -102,7 +102,7 @@ part of the \Cpp standard library, they should not be declared directly within n
 
 \pnum
 The International Standard, ISO/IEC 14882, together with ISO/IEC TS 19217:2015 (the Concepts TS),
-provide important context and specification for this paper. In places, this document suggests
+provide important context and specification for this document. In places, this document suggests
 changes to be made to components in namespace \tcode{std} in-place. In
 other places, entire chapters and sections are copied from ISO/IEC 14882 and modified so as to
 define similar but different components in namespace \tcode{std::experimental::ranges::v1}.
@@ -114,7 +114,7 @@ Modifications made to existing text from the International Standard use
 represent deleted text.
 
 \pnum
-This paper assumes that the contents of the \tcode{std::experimental::ranges::v1}
+This document assumes that the contents of the \tcode{std::experimental::ranges::v1}
 namespace will become a new constrained version of the \Cpp Standard Library
 that will be delivered alongside the existing unconstrained version.
 


### PR DESCRIPTION
Fixes #303.

Per ISO/IEC directives part 2 §10.6 "References in a document to itself":

> For an individual document, the form "this document" shall be used. 