### PR TITLE
Fix capitalization in clause titles

### DIFF
--- a/intro.tex
+++ b/intro.tex
@@ -77,7 +77,7 @@ of the referenced document (including any amendments) applies.
 ISO/IEC 14882:2014 is herein called the \defn{\Cpp Standard}, N3351 is called the
 \defn{``The Palo Alto''} report, and ISO/IEC TS 19217:2015 is called the \defn{Concepts TS}.
 
-\rSec0[intro.defs]{Terms and Definitions}
+\rSec0[intro.defs]{Terms and definitions}
 
 \pnum
 Terms defined in \cxxref{definitions} are used in this document with the same
@@ -102,7 +102,7 @@ sorts the pairs in increasing order of their \tcode{first} members:
 \end{codeblock}
 \exitexample
 
-\rSec0[intro]{General Principles}
+\rSec0[intro]{General principles}
 
 \rSec1[intro.compliance]{Implementation compliance}
 


### PR DESCRIPTION
Prevailing convention appears to be capitalizing only the first letter.