### PR TITLE
Apply P0663R0 PR for #251: algorithms incorrectly specified in terms …

### DIFF
--- a/algorithms.tex
+++ b/algorithms.tex
@@ -1903,7 +1903,7 @@ starting from first and proceeding to last.
 For each non-negative integer
 \tcode{n < (last-first)},
 performs
-\tcode{*(result + n)} \tcode{= std::move(*(first + n))}.
+\tcode{*(result + n) = ranges::iter_move(first + n)}.
 
 \pnum
 \returns
@@ -1951,7 +1951,7 @@ the range
 For each positive integer
 \tcode{n <= (last - first)},
 performs
-\tcode{*(result - n) = std::move(*(last - n))}.
+\tcode{*(result - n) = ranges::iter_move(last - n)}.
 
 \pnum
 \requires
@@ -1989,8 +1989,8 @@ template <ForwardRange Rng1, ForwardRange Rng2>
 \pnum
 \effects
 For each non-negative integer \tcode{n < min(last1 - first1, last2 - first2)}
-performs:
-\tcode{swap(*(first1 + n), \brk{}*(first2 + n))}.
+performs: \\
+\tcode{ranges::iter_swap(first1 + n, first2 + n)}.
 
 \pnum
 \requires


### PR DESCRIPTION
…of `swap(*a,*b)` instead `iter_swap(a,b)`, and `move(*a)` instead of `iter_move(a)`

Fixes #251.
