### PR TITLE
Apply P0663R0 PR for 309: Missing “Returns:” clause of sort/stable_so…

### DIFF
--- a/algorithms.tex
+++ b/algorithms.tex
@@ -2971,6 +2971,9 @@ Sorts the elements in the range
 \range{first}{last}.
 
 \pnum
+\returns \tcode{last}.
+
+\pnum
 \complexity
 \bigoh{N\log(N)}
 (where
@@ -2997,6 +3000,9 @@ template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 \pnum
 \effects
 Sorts the elements in the range \range{first}{last}.
+
+\pnum
+\returns \tcode{last}.
 
 \pnum
 \complexity
@@ -3039,6 +3045,9 @@ The rest of the elements in the range
 \range{middle}{last}
 are placed in an unspecified order.
 \indextext{unspecified}%
+
+\pnum
+\returns \tcode{last}.
 
 \pnum
 \complexity
@@ -3165,6 +3174,9 @@ in the range
 \range{nth}{last}
 it holds that:
 \tcode{invoke(comp, invoke(proj, *j), invoke(proj, *i)) == false}.
+
+\pnum
+\returns \tcode{last}.
 
 \pnum
 \complexity


### PR DESCRIPTION
…rt/partial_sort/nth_element

Fixes #309.