### PR TITLE
Apply P0663R0 PR for 317: is_nothrow_indirectly_movable could be true…

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -1699,6 +1699,7 @@ template <class In, class Out>
   requires IndirectlyMovable<In, Out>
 struct is_nothrow_indirectly_movable<In, Out> :
   integral_constant<bool,
+    noexcept(ranges::iter_move(declval<In&>())) &&
     is_nothrow_constructible<value_type_t<In>, rvalue_reference_t<In>>::value &&
     is_nothrow_assignable<value_type_t<In> &, rvalue_reference_t<In>>::value &&
     is_nothrow_assignable<reference_t<Out>, rvalue_reference_t<In>>::value &&


### PR DESCRIPTION
… even when iter_move is noexcept(false)

Fixes #317.