### PR TITLE
Apply P0740R0 PR for 156: Validity of references obtained from out-of…

### DIFF
--- a/iterators.tex
+++ b/iterators.tex
@@ -1296,6 +1296,10 @@ may be compared and shall compare equal to other value-initialized iterators of 
 the same empty sequence. \exitnote
 
 \pnum
+Pointers and references obtained from a forward iterator into a range \range{i}{s}
+shall remain valid while \range{i}{s} continues to denote a range.
+
+\pnum
 Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X} offer the
 \defn{multi-pass guarantee} if:
 


### PR DESCRIPTION
…-lifetime iterators

Fixes #156.

Note that I chose to place the new para *before* para 3 instead of after para 4. I was concerned that readers could too easily miss that the new para adds a normative requirement if it appeared after the large note in para 3.