### PR TITLE
Apply P0740R0 PR for 262: Use expression-equivalent in definitions of…

### DIFF
--- a/ranges-lib.tex
+++ b/ranges-lib.tex
@@ -19,6 +19,15 @@ as summarized in Table~\ref{tab:ranges.lib.summary}.
   \ref{ranges.requirements} & Requirements      & \\
 \end{libsumtab}
 
+\rSec1[ranges.decaycopy]{decay_copy}
+
+\pnum
+Several places in this Clause use the expression \tcode{\textit{DECAY_COPY}(x)},
+which is expression-equivalent to:
+\begin{codeblock}
+  decay_t<decltype((x))>(x)
+\end{codeblock}
+
 \rSec1[range.synopsis]{Header \tcode{<experimental/ranges/range>} synopsis}
 
 \indexlibrary{\idxhdr{experimental/ranges/range}}%
@@ -117,8 +126,8 @@ available when \tcode{<experimental/ranges/iterator>} is included.
 \rSec2[range.access.begin]{\tcode{begin}}
 \pnum
 The name \tcode{begin} denotes a customization point
- object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::begin(E)} for some expression \tcode{E} is equivalent to:
+ object~(\ref{customization.point.object}). The expression
+\tcode{ranges::begin(E)} for some subexpression \tcode{E} is expression-equivalent to:
 
 \begin{itemize}
 \item
@@ -133,13 +142,13 @@ The name \tcode{begin} denotes a customization point
   type~(\cxxref{basic.compound}).
 
 \item
-  Otherwise, \tcode{DECAY_COPY((E).begin())} if it is a valid expression and its type \tcode{I} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}((E).begin())} if it is a valid expression and its type \tcode{I} meets the
   syntactic requirements of \tcode{Iterator<I>}. If
   \tcode{Iterator} is not satisfied, the program is ill-formed
   with no diagnostic required.
 
 \item
-  Otherwise, \tcode{DECAY_COPY(begin(E))} if it is a valid expression and its type \tcode{I} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}(begin(E))} if it is a valid expression and its type \tcode{I} meets the
   syntactic requirements of \tcode{Iterator<I>} with overload
   resolution performed in a context that includes the declaration
   \tcode{void begin(auto\&) = delete;} and does not include
@@ -158,8 +167,8 @@ type satisfies \tcode{Iterator}. \exitnote
 \rSec2[range.access.end]{\tcode{end}}
 \pnum
 The name \tcode{end} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::end(E)} for some expression \tcode{E} is equivalent to:
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::end(E)} for some subexpression \tcode{E} is expression-equivalent to:
 
 \begin{itemize}
 \item
@@ -174,14 +183,14 @@ object~(\ref{customization.point.object}). The effect of the expression
   type~(\cxxref{basic.compound}) \tcode{T}.
 
 \item
-  Otherwise, \tcode{DECAY_COPY((E).end())} if it is a valid expression and its type \tcode{S} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}((E).end())} if it is a valid expression and its type \tcode{S} meets the
   syntactic requirements of
   \tcode{Sentinel<\brk{}S, decltype(\brk{}ranges::\brk{}begin(E))>}. If
   \tcode{Sentinel} is not satisfied, the program is ill-formed with
   no diagnostic required.
 
 \item
-  Otherwise, \tcode{DECAY_COPY(end(E))} if it is a valid expression and its type \tcode{S} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}(end(E))} if it is a valid expression and its type \tcode{S} meets the
   syntactic requirements of
   \tcode{Sentinel<\brk{}S, decltype(\brk{}ranges::\brk{}begin(E))>} with overload
   resolution performed in a context that includes the declaration
@@ -201,9 +210,9 @@ types of \tcode{ranges::end(E)} and \tcode{ranges::\brk{}begin(E)} satisfy
 \rSec2[range.access.cbegin]{\tcode{cbegin}}
 \pnum
 The name \tcode{cbegin} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::\brk{}cbegin(E)} for some expression \tcode{E} of type \tcode{T}
-is equivalent to \tcode{ranges::\brk{}begin(static_cast<const T\&>(E))}.
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::\brk{}cbegin(E)} for some subexpression \tcode{E} of type \tcode{T}
+is expression-equivalent to \tcode{ranges::\brk{}begin(static_cast<const T\&>(E))}.
 
 \pnum
 Use of \tcode{ranges::cbegin(E)} with rvalue \tcode{E} is deprecated.
@@ -218,9 +227,9 @@ type satisfies \tcode{Iterator}. \exitnote
 \rSec2[range.access.cend]{\tcode{cend}}
 \pnum
 The name \tcode{cend} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::cend(E)} for some expression \tcode{E} of type \tcode{T}
-is equivalent to \tcode{ranges::end(static_cast<const T\&>(E))}.
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::cend(E)} for some subexpression \tcode{E} of type \tcode{T}
+is expression-equivalent to \tcode{ranges::end(static_cast<const T\&>(E))}.
 
 \pnum
 Use of \tcode{ranges::cend(E)} with rvalue \tcode{E} is deprecated.
@@ -236,8 +245,8 @@ types of \tcode{ranges::cend(E)} and \tcode{ranges::cbegin(E)} satisfy
 \rSec2[range.access.rbegin]{\tcode{rbegin}}
 \pnum
 The name \tcode{rbegin} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::rbegin(E)} for some expression \tcode{E} is equivalent
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::rbegin(E)} for some subexpression \tcode{E} is expression-equivalent
 to:
 
 \begin{itemize}
@@ -249,7 +258,7 @@ to:
   as defined in ISO/IEC 14882 when \tcode{E} is an rvalue. \exitnote
 
 \item
-  Otherwise, \tcode{DECAY_COPY((E).rbegin())} if it is a valid expression and its type \tcode{I} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}((E).rbegin())} if it is a valid expression and its type \tcode{I} meets the
   syntactic requirements of \tcode{Iterator<I>}. If \tcode{Iterator}
   is not satisfied, the program is ill-formed with no diagnostic
   required.
@@ -271,8 +280,8 @@ type satisfies \tcode{Iterator}. \exitnote
 \rSec2[range.access.rend]{\tcode{rend}}
 \pnum
 The name \tcode{rend} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::rend(E)} for some expression \tcode{E} is equivalent to:
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::rend(E)} for some subexpression \tcode{E} is expression-equivalent to:
 
 \begin{itemize}
 \item
@@ -283,7 +292,7 @@ object~(\ref{customization.point.object}). The effect of the expression
   as defined in ISO/IEC 14882 when \tcode{E} is an rvalue. \exitnote
 
 \item
-  Otherwise, \tcode{DECAY_COPY((E).rend())} if it is a valid expression and its type \tcode{S} meets the
+  Otherwise, \tcode{\textit{DECAY_COPY}((E).rend())} if it is a valid expression and its type \tcode{S} meets the
   syntactic requirements of
   \tcode{Sentinel<\brk{}S, decltype(\brk{}ranges::\brk{}rbegin(E))>}. If
   \tcode{Sentinel} is not satisfied, the program is ill-formed with
@@ -307,9 +316,9 @@ types of \tcode{ranges::rend(E)} and \tcode{ranges::rbegin(E)} satisfy
 \rSec2[range.access.crbegin]{\tcode{crbegin}}
 \pnum
 The name \tcode{crbegin} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::\brk{}crbegin(E)} for some expression \tcode{E} of type \tcode{T}
-is equivalent to \tcode{ranges::\brk{}rbegin(static_cast<const T\&>(E))}.
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::\brk{}crbegin(E)} for some subexpression \tcode{E} of type \tcode{T}
+is expression-equivalent to \tcode{ranges::\brk{}rbegin(static_cast<const T\&>(E))}.
 
 \pnum
 Use of \tcode{ranges::crbegin(E)} with rvalue \tcode{E} is deprecated.
@@ -324,9 +333,9 @@ type satisfies \tcode{Iterator}. \exitnote
 \rSec2[range.access.crend]{\tcode{crend}}
 \pnum
 The name \tcode{crend} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::crend(E)} for some expression \tcode{E} of type \tcode{T}
-is equivalent to \tcode{ranges::rend(static_cast<const T\&>(E))}.
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::crend(E)} for some subexpression \tcode{E} of type \tcode{T}
+is expression-equivalent to \tcode{ranges::rend(static_cast<const T\&>(E))}.
 
 \pnum
 Use of \tcode{ranges::crend(E)} with rvalue \tcode{E} is deprecated.
@@ -349,23 +358,23 @@ available when \tcode{<experimental/ranges/iterator>} is included.
 \rSec2[range.primitives.size]{\tcode{size}}
 \pnum
 The name \tcode{size} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::size(E)} for some expression \tcode{E} with type
-\tcode{T} is equivalent to:
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::size(E)} for some subexpression \tcode{E} with type
+\tcode{T} is expression-equivalent to:
 
 \begin{itemize}
 \item
-  \tcode{extent<T>::value} if \tcode{T} is an array
+  \tcode{\textit{DECAY_COPY}(extent<T>::value)} if \tcode{T} is an array
   type~(\cxxref{basic.compound}).
 
 \item
-  Otherwise, \tcode{DECAY_COPY(static_cast<const T\&>(E).size())} if it is a valid expression and its type \tcode{I}
+  Otherwise, \tcode{\textit{DECAY_COPY}(static_cast<const T\&>(E).size())} if it is a valid expression and its type \tcode{I}
   satisfies \tcode{Integral<I>} and
   \tcode{disable_\-sized_\-range<T>}~(\ref{ranges.sized}) is
   \tcode{false}.
 
 \item
-  Otherwise, \tcode{DECAY_COPY(size(static_cast<const T\&>(E)))} if it is a valid expression and its type \tcode{I}
+  Otherwise, \tcode{\textit{DECAY_COPY}(size(static_cast<const T\&>(E)))} if it is a valid expression and its type \tcode{I}
   satisfies \tcode{Integral<I>} with overload resolution
   performed in a context that includes the declaration
   \tcode{void size(const auto\&) = delete;} and does not include
@@ -374,7 +383,7 @@ object~(\ref{customization.point.object}). The effect of the expression
 
 \item
   Otherwise,
-  \tcode{DECAY_COPY(ranges::cend(E) - ranges::cbegin(E))}, except that \tcode{E}
+  \tcode{\textit{DECAY_COPY}(ranges::cend(E) - ranges::cbegin(E))}, except that \tcode{E}
   is only evaluated once, if it is a valid expression and the types \tcode{I} and \tcode{S} of
   \tcode{ranges::cbegin(E)} and \tcode{ranges::cend(E)} meet the
   syntactic requirements of
@@ -394,9 +403,9 @@ type satisfies \tcode{Integral}. \exitnote
 \rSec2[range.primitives.empty]{\tcode{empty}}
 \pnum
 The name \tcode{empty} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::empty(E)} for some expression \tcode{E} is
-equivalent to:
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::empty(E)} for some subexpression \tcode{E} is
+expression-equivalent to:
 
 \begin{itemize}
 \item
@@ -421,9 +430,9 @@ has type \tcode{bool}. \exitnote
 \rSec2[range.primitives.data]{\tcode{data}}
 \pnum
 The name \tcode{data} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::data(E)} for some expression \tcode{E} is
-equivalent to:
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::data(E)} for some subexpression \tcode{E} is
+expression-equivalent to:
 
 \begin{itemize}
 \item
@@ -434,7 +443,7 @@ equivalent to:
   Paper when \tcode{E} is an rvalue. \exitnote
 
 \item
-  Otherwise, \tcode{DECAY_COPY((E).data())} if it is a valid expression of pointer to object type.
+  Otherwise, \tcode{\textit{DECAY_COPY}((E).data())} if it is a valid expression of pointer to object type.
 
 \item
   Otherwise, \tcode{ranges::begin(E)} if it is a valid expression of pointer to object type.
@@ -450,9 +459,9 @@ has pointer to object type. \exitnote
 \rSec2[range.primitives.cdata]{\tcode{cdata}}
 \pnum
 The name \tcode{cdata} denotes a customization point
-object~(\ref{customization.point.object}). The effect of the expression
-\tcode{ranges::cdata(E)} for some expression \tcode{E} of type \tcode{T}
-is equivalent to \tcode{ranges::data(static_cast<const T\&>(E))}.
+object~(\ref{customization.point.object}). The expression
+\tcode{ranges::cdata(E)} for some subexpression \tcode{E} of type \tcode{T}
+is expression-equivalent to \tcode{ranges::data(static_cast<const T\&>(E))}.
 
 \pnum
 Use of \tcode{ranges::cdata(E)} with rvalue \tcode{E} is deprecated.


### PR DESCRIPTION
… CPOs

Fixes #262.

Editorial:
* format all occurrences of `DECAY_COPY` with `\textit` to be consistent with the formatting of metasyntactic macros in the IS
* Place the new subclause "decay_copy" after [ranges.general] instead of [iterators.general] since we actually use it in the Ranges Clause.
