### PR TITLE
Fix duplicate labels likely caused by c&p errors

### DIFF
--- a/ext/adaptors/ranges-lib.tex
+++ b/ext/adaptors/ranges-lib.tex
@@ -1090,7 +1090,7 @@ is an alias for \tcode{ranges::forward_iterator_tag}.
 \tcode{ranges::input_iterator_tag}.
 \end{itemize}
 
-\rSec4[ranges.adaptors.filter_view.iterator]{\tcode{filter_view::iterator} operations}
+\rSec4[ranges.adaptors.filter_view.iterator.ops]{\tcode{filter_view::iterator} operations}
 \rSec5[ranges.adaptors.filter_view.iterator.ctor]{\tcode{filter_view::iterator} constructors}
 
 \indexlibrary{\idxcode{iterator}!\idxcode{filter_view::iterator}}%
@@ -2277,7 +2277,7 @@ constexpr iterator end() const requires Same<I, Bound>;
 \returns \tcode{iterator\{bound_\}}.
 \end{itemdescr}
 
-\rSec4[ranges.adaptors.iota_view.end]{\tcode{iota_view} range end}
+\rSec4[ranges.adaptors.iota_view.size]{\tcode{iota_view} range size}
 
 \indexlibrary{\idxcode{size}!\idxcode{iota_view}}%
 \begin{itemdecl}
@@ -2652,7 +2652,7 @@ namespace std { namespace experimental { namespace ranges { inline namespace v1 
 }}}}
 \end{codeblock}
 
-\rSec4[ranges.adaptors.iota_view.ctor]{\tcode{iota_view::sentinel} constructors}
+\rSec4[ranges.adaptors.iota_view.sentinel.ctor]{\tcode{iota_view::sentinel} constructors}
 
 \indexlibrary{\idxcode{sentinel}!\idxcode{iota_view::sentinel}}
 \begin{itemdecl}
@@ -2664,7 +2664,7 @@ constexpr explicit sentinel(Bound bound);
 \effects Initializes \tcode{bound_} with \tcode{bound}.
 \end{itemdescr}
 
-\rSec4[ranges.adaptors.iota_view.comp]{\tcode{iota_view::sentinel} comparisons}
+\rSec4[ranges.adaptors.iota_view.sentinel.cmp]{\tcode{iota_view::sentinel} comparisons}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{iota_view::sentinel}}
 \begin{itemdecl}


### PR DESCRIPTION
also, ranges.adaptors.iota_view.comp => ranges.adaptors.iota_view.sentinel.cmp, to match the tag for iteraotr comparisons