### PR TITLE
Use \texorpdfstring in \xname to suppress hyperref warnings

### DIFF
--- a/ext/adaptors/macros.tex
+++ b/ext/adaptors/macros.tex
@@ -228,7 +228,7 @@
 %% Double underscore
 \newcommand{\ungap}{\kern.5pt}
 \newcommand{\unun}{\_\ungap\_}
-\newcommand{\xname}[1]{\unun\ungap#1}
+\newcommand{\xname}[1]{\texorpdfstring{\unun\ungap#1}{\_\_#1}}
 \newcommand{\mname}[1]{\tcode{\unun\ungap#1\ungap\unun}}
 
 %% Ranges


### PR DESCRIPTION
No visual change.