### PR TITLE
[P0896] indirect_result fixes

### DIFF
--- a/ext/merge2std2/iterators.tex
+++ b/ext/merge2std2/iterators.tex
@@ -1034,11 +1034,11 @@ callable objects~(\cxxref{func.def}) as arguments.
     StrictWeakOrder<F&, reference_t<I1>, reference_t<I2>> &&
     StrictWeakOrder<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
-  template <class> struct indirect_result@\oldtxt{_of}@ { };
+  @\oldtxt{template <class> struct indirect_result_of \{ \};}@
 
   template <class F, class... Is>
-    requires Invocable<F, reference_t<Is>...>
-  struct indirect_result@\oldtxt{_of}@<F(Is...)> :
+    requires @\newtxt{(Readable<Is> \&\& ...) \&\&}@ Invocable<F, reference_t<Is>...>
+  struct indirect_result@\oldtxt{_of}@<F@\oldtxt{(}\newtxt{, }@Is...@\oldtxt{)}@> :
     @\oldtxt{result_of<F(reference_t<Is>\&\&...)>}\newtxt{invoke_result<F, reference_t<Is>...>}@ { };
 \end{codeblock}
 

--- a/ext/merge2std2/ranges-lib.tex
+++ b/ext/merge2std2/ranges-lib.tex
@@ -148,15 +148,16 @@ namespace std { @\oldtxt{namespace experimental \{}@
     template <class F, class I1, class I2 = I1>
     concept @\oldtxt{bool}@ IndirectStrictWeakOrder = @\seebelow@;
 
-    template <class> struct indirect_result@\oldtxt{_of}@;
+    template <class@\newtxt{, class...}@>
+    struct indirect_result@\oldtxt{_of}@ @\newtxt{\{ \}}@;
 
     template <class F, class... Is>
-      requires Invocable<F, reference_t<Is>...>
-    struct indirect_result@\oldtxt{_of}@<F(Is...)>;
+      requires @\newtxt{(Readable<Is> \&\& ...) \&\&}@ Invocable<F, reference_t<Is>...>
+    struct indirect_result@\oldtxt{_of}@<F@\oldtxt{(}\newtxt{, }@Is...@\oldtxt{)}@>;
 
-    template <class F>
+    template <class F@\newtxt{, class... Is}@>
     using indirect_result@\oldtxt{_of}@_t
-      = typename indirect_result@\oldtxt{_of}@<F>::type;
+      = typename indirect_result@\oldtxt{_of}@<F@\newtxt{, Is...}@>::type;
 
     // \ref{range.projected}, projected:
     template <Readable I, IndirectRegularUnaryInvocable<I> Proj>


### PR DESCRIPTION
* variadic instead of single-function-type parameter
* require the `Is...` to be `Readable` before using `reference_t` on them